### PR TITLE
GEN-5206 describe exception 해결

### DIFF
--- a/run_describe_vpc.py
+++ b/run_describe_vpc.py
@@ -72,7 +72,7 @@ def describe_eb_route_tables(vpc_id=None):
 
 def describe_eb_security_groups(vpc_id=None):
     if not vpc_id:
-        vpc_id = 'vpc-test-1234'
+        return False
 
     cmd = ['ec2', 'describe-security-groups']
     cmd += ['--filters=Name=vpc-id,Values=%s' % vpc_id]
@@ -116,7 +116,7 @@ def describe_rds_route_tables(vpc_id=None):
 
 def describe_rds_security_groups(vpc_id=None):
     if not vpc_id:
-        vpc_id = 'vpc-test-1234'
+        return False
 
     cmd = ['ec2', 'describe-security-groups']
     cmd += ['--filters=Name=vpc-id,Values=%s' % vpc_id]

--- a/run_describe_vpc.py
+++ b/run_describe_vpc.py
@@ -71,7 +71,7 @@ def describe_eb_route_tables(vpc_id=None):
 
 
 def describe_eb_security_groups(vpc_id=None):
-    if not vpc_id :
+    if not vpc_id:
         vpc_id = 'vpc-test-1234'
 
     cmd = ['ec2', 'describe-security-groups']
@@ -115,7 +115,7 @@ def describe_rds_route_tables(vpc_id=None):
 
 
 def describe_rds_security_groups(vpc_id=None):
-    if not vpc_id :
+    if not vpc_id:
         vpc_id = 'vpc-test-1234'
 
     cmd = ['ec2', 'describe-security-groups']

--- a/run_describe_vpc.py
+++ b/run_describe_vpc.py
@@ -70,7 +70,7 @@ def describe_eb_route_tables(vpc_id=None):
         return True
 
 
-def describe_eb_security_groups(vpc_id=None):
+def describe_eb_security_groups(vpc_id):
     if not vpc_id:
         return False
 
@@ -114,7 +114,7 @@ def describe_rds_route_tables(vpc_id=None):
         return True
 
 
-def describe_rds_security_groups(vpc_id=None):
+def describe_rds_security_groups(vpc_id):
     if not vpc_id:
         return False
 

--- a/run_describe_vpc.py
+++ b/run_describe_vpc.py
@@ -71,6 +71,9 @@ def describe_eb_route_tables(vpc_id=None):
 
 
 def describe_eb_security_groups(vpc_id=None):
+    if not vpc_id :
+        vpc_id = 'vpc-test-1234'
+
     cmd = ['ec2', 'describe-security-groups']
     cmd += ['--filters=Name=vpc-id,Values=%s' % vpc_id]
     result = aws_cli.run(cmd, ignore_error=True)
@@ -112,6 +115,9 @@ def describe_rds_route_tables(vpc_id=None):
 
 
 def describe_rds_security_groups(vpc_id=None):
+    if not vpc_id :
+        vpc_id = 'vpc-test-1234'
+
     cmd = ['ec2', 'describe-security-groups']
     cmd += ['--filters=Name=vpc-id,Values=%s' % vpc_id]
     result = aws_cli.run(cmd, ignore_error=True)


### PR DESCRIPTION
- describe_rds_security_groups
  - vpc-id가 None일 경우 임의의 정상 테스트용 파라메터를 넣었습니다.
- describe_eb_security_groups
  - vpc-id가 None일 경우 임의의 정상 테스트용 파라메터를 넣었습니다.

<https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-security-groups.html>

언제부터 바뀐지에 대한 정보는 찾지 못하였고, 파라메터 검사에 대한 여부에 대한 정보는 없었습니다.

테스트를 해본 결과 Security_groups 조회하는 cli 명령어가 파라메터를 검사하게끔 변한 것 같습니다.
vpc-id 에대서 파라메터를 'vpc- ' 로 시작해야 올바른 파라메터로 인식하고 돌려주게 패치된 것 같습니다.