### PR TITLE
GEN-5764 add sms widget

### DIFF
--- a/aws_iam/aws-sns-sms-log-policy.json
+++ b/aws_iam/aws-sns-sms-log-policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:PutMetricFilter",
+                "logs:PutRetentionPolicy"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/aws_iam/aws-sns-sms-log-role.json
+++ b/aws_iam/aws-sns-sms-log-role.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "sns.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/run_create_cloudwatch_dashboard.py
+++ b/run_create_cloudwatch_dashboard.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
 
 
 def create_sms_log():
-    aws_cli = AWSCli('us-east-1')
+    aws_cli = AWSCli('ap-northeast-1')
 
     role_name = 'aws-sns-sms-log-role'
     policy_name = 'aws-sns-sms-log-policy'
@@ -244,8 +244,6 @@ def run_create_cw_dashboard_sqs_lambda_sms(name, settings):
     with open(filename_path, 'r') as ff:
         dashboard_body = json.load(ff)
 
-    print(dashboard_body['widgets'])
-
     for dw in dashboard_body['widgets']:
         pm = dw['properties']['metrics']
 
@@ -320,7 +318,7 @@ def run_create_cw_dashboard_alarm(name, settings):
 ################################################################################
 print_session('create cloudwatch dashboard')
 
-reset_template_dir()
+# reset_template_dir()
 
 cw = env.get('cloudwatch', dict())
 target_cw_dashboard_name = None

--- a/run_create_cloudwatch_dashboard.py
+++ b/run_create_cloudwatch_dashboard.py
@@ -318,7 +318,7 @@ def run_create_cw_dashboard_alarm(name, settings):
 ################################################################################
 print_session('create cloudwatch dashboard')
 
-# reset_template_dir()
+reset_template_dir()
 
 cw = env.get('cloudwatch', dict())
 target_cw_dashboard_name = None

--- a/run_terminate_cloudwatch_dashboard.py
+++ b/run_terminate_cloudwatch_dashboard.py
@@ -28,7 +28,7 @@ def run_terminate_cw_dashboard(name, settings):
 
 
 def delete_role_for_sms():
-    aws_cli = AWSCli('us-east-1')
+    aws_cli = AWSCli('ap-northeast-1')
 
     role_name = 'aws-sns-sms-log-role'
     policy_name = 'aws-sns-sms-log-policy'
@@ -68,15 +68,10 @@ if len(args) == 2:
         if cw_dashboard_env['NAME'] == target_cw_dashboard_name:
             target_cw_dashboard_name_exists = True
             run_terminate_cw_dashboard(cw_dashboard_env['NAME'], cw_dashboard_env)
-
-            if cw_dashboard_env['TYPE'] == 'sqs,lambda,sms':
-                delete_role_for_sms()
-
     if not target_cw_dashboard_name_exists:
         print('"%s" is not exists in config.json' % target_cw_dashboard_name)
 else:
     for cw_dashboard_env in cw.get('DASHBOARDS', list()):
         run_terminate_cw_dashboard(cw_dashboard_env['NAME'], cw_dashboard_env)
 
-        if cw_dashboard_env['TYPE'] == 'sqs,lambda,sms':
-            delete_role_for_sms()
+delete_role_for_sms()


### PR DESCRIPTION
## 작업내역
- sms 전송 갯수 표시 위젯을 추가함
- terminate 시킬시 log 에 등록 하지 않도록 하지만 Delivery statistics 는 꺼지지 않는다. 물리적으로 끌 수 있는 기능은 없어 보임

## 테스트 가이드
- `./run_create_cloudwatch_dashboard.py` 를 하면, magi 를 매번 받아와서, `cloudwatch/__global___ap-northeast-2.json` 파일이 계속 master 에서 가져오는데, 아래 코드를 주석 치고 https://github.com/HardBoiledSmith/magi/pull/462 에 `cloudwatch/__global___ap-northeast-2.json` 
 에서 받아 magi 를 직접 수정 해주면 편하다.
   - https://github.com/HardBoiledSmith/johanna/blob/b7ff82fc5bf05ed41d3e59188cb22b4f742f59cf/run_create_cloudwatch_dashboard.py#L323
- us-east-1 리전으로 변경 하고 SNS > Text messaging (SMS) > Publish text message 로 메시지를 보내 준다
- johanna 로 `./run_create_cloudwatch_dashboard.py __global__` 실행하면 아래와 같이 나오는는데, `SNS: send sms` 생기면 성공이다.
<img width="1679" alt="스크린샷 2019-09-18 오후 1 36 55" src="https://user-images.githubusercontent.com/11402853/65112086-68df1a00-da19-11e9-821d-f6cd7c9a6dfe.png">
- `./run_terminate_cloudwatch_dashboard.py -f` 하면, 위젯들은 다 사리지고,  SNS > Text messaging (SMS) >Text messaging preferences 에 Edit 버튼을 누르면 아래와 같이 값이 비어 있으면 제대로 된 것 이다.
<img width="937" alt="스크린샷 2019-09-18 오후 1 41 19" src="https://user-images.githubusercontent.com/11402853/65112302-279b3a00-da1a-11e9-9ce1-acdff656d49c.png">
