### PR TITLE
GEN-5528 Add cloudwatch alarm for lambda error

### DIFF
--- a/run_terminate_cloudwatch_alarm.py
+++ b/run_terminate_cloudwatch_alarm.py
@@ -19,7 +19,8 @@ def run_terminate_cw_alarm(name, settings):
     aws_cli = AWSCli(region)
 
     ################################################################################
-    alarm_name = '%s-%s_%s_%s' % (phase, name, region, settings['METRIC_NAME'])
+    metric_name = settings.get('METRIC_NAME', 'NotSuccessIn5Min')
+    alarm_name = '%s-%s_%s_%s' % (phase, name, region, metric_name)
 
     if settings['TYPE'] == 'sqs':
         sqs_name = settings['QUEUE_NAME']


### PR DESCRIPTION
### What is this PR for?
- lambda 들에 대해서 Error count Cloudwatch 모니터링 강화
- dashbord 의 경우는 아래 코드로 인해 자동으로 생성됨
    - error count 로 하려고 했으나 alarm용 widget 이여서, 성공 여부를 보여주는 차트나을 것 같아 따로 작업 하지 않음
https://github.com/HardBoiledSmith/johanna/blob/master/run_create_cloudwatch_dashboard.py#L273-L311

### How should this be tested?
- `run_create_lambda.py <name>` 으로 lambda 를 생성
- config.json 에 `cloudwatch.ALARMS` 에 아래 같은 설정을 추가함
```
{
      "AWS_DEFAULT_REGION": <region>,
      "COMPARISON_OPERATOR": "LessThanThreshold",
      "DATAPOINTS_TO_ALARM": "1",
      "DESCRIPTION": "Success of <name> (<region>) is less than 100 in 5min", 
      "EVALUATION_PERIODS": "1",
      "NAME": <name>,
      "SNS_TOPIC_NAME": "cloudwatch-alarm",
      "THRESHOLD": "100.0",
      "TYPE": "lambda"
}
```
- `run_create_cloudwatch_alarm.py <name>` 으로 alarm 를 생성
- `run_create_cloudwatch_dashboard.py <alarm name>` 으로 alarm widget 를 생성

### Screenshots (if appropriate)

#### dashboard 화면
<img width="1680" alt="스크린샷 2019-10-02 오후 4 43 13" src="https://user-images.githubusercontent.com/11402853/66027227-70341680-e535-11e9-92a3-40ab918fd941.png">

#### alarm 화면
<img width="1680" alt="스크린샷 2019-10-02 오후 4 43 34" src="https://user-images.githubusercontent.com/11402853/66027228-70341680-e535-11e9-83ad-ec1675d9d5dc.png">
<img width="1680" alt="스크린샷 2019-10-02 오후 4 43 25" src="https://user-images.githubusercontent.com/11402853/66027229-70ccad00-e535-11e9-9d7d-c65c205bef74.png">
