### PR TITLE
GEN-6146 update windows version

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -347,7 +347,7 @@ def run_create_eb_windows(name, settings):
     cmd += ['--cname-prefix', cname]
     cmd += ['--environment-name', eb_environment_name]
     cmd += ['--option-settings', option_settings]
-    cmd += ['--solution-stack-name', '64bit Windows Server 2016 v2.2.1 running IIS 10.0']
+    cmd += ['--solution-stack-name', '64bit Windows Server 2016 v2.2.2 running IIS 10.0']
     cmd += ['--tags', tag0, tag1]
     cmd += ['--version-label', eb_environment_name]
     aws_cli.run(cmd, cwd=template_path)


### PR DESCRIPTION
### What is this PR for?
- Elasticbeanstalk python, windows 버전 최신으로 업데이트

https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.python

python은 최신 버전이 `64bit Amazon Linux 2018.03 v2.9.2 running Python 3.6`으로 이미 최신 버전이어서 수정할 것이 없었습니다.

### How should this be tested?
- 제가 아직 johanna 및 aws_cli에 미숙하여 따로 테스트를 진행해보지 못했습니다.. pr close 한 후 테스트 이후 다시 열겠습니다.
