### PR TITLE
GEN-6157 Add Configuration Sets sns Destination

### DIFF
--- a/run_create_ses.py
+++ b/run_create_ses.py
@@ -94,9 +94,7 @@ def create_config_set():
                     }
                 })
 
-
         config['EVENT_DESTINATIONS'] = ll
-
 
         if config_set['NAME'] not in exist_config_names:
             cmd = ['ses', 'create-configuration-set',

--- a/run_create_ses.py
+++ b/run_create_ses.py
@@ -61,23 +61,42 @@ def create_config_set():
 
     exist_config_names = [exist_config_set['Name'] for exist_config_set in exist_config_sets]
     for config_set in ses['CONFIGURATION_SETS']:
-        config = {
-            "NAME": config_set['NAME'],
-            "EVENT_DESTINATIONS": [{
-                "Name": config_set['EVENT_DESTINATIONS_NAME'],
-                "Enabled": config_set['EVENT_DESTINATIONS_Enabled'],
-                "MatchingEventTypes": config_set['MATCHING_TYPE'],
-                "CloudWatchDestination": {
-                    "DimensionConfigurations": [
-                        {
-                            "DimensionName": config_set['DIMENSION_CONFIG_NAME'],
-                            "DimensionValueSource": config_set['DIMENSION_CONFIG_VALUE_SOURCE'],
-                            "DefaultDimensionValue": config_set['DIMENSION_CONFIG_VALUE']
-                        }
-                    ]
-                }
-            }]
-        }
+        config = dict()
+        config['NAME'] = config_set['NAME']
+        ll = list()
+        for event_destination in config_set['EVENT_DESTINATIONS']:
+            if event_destination['TYPE'] == 'cloudwatch':
+                ll.append({
+                    "Name": event_destination['NAME'],
+                    "Enabled": event_destination['ENABLED'],
+                    "MatchingEventTypes": event_destination['MATCHING_TYPE'],
+                    "CloudWatchDestination": {
+                        "DimensionConfigurations": [
+                            {
+                                "DimensionName": event_destination['DIMENSION_CONFIG_NAME'],
+                                "DimensionValueSource": event_destination['DIMENSION_CONFIG_VALUE_SOURCE'],
+                                "DefaultDimensionValue": event_destination['DIMENSION_CONFIG_VALUE']
+                            }
+                        ]
+                    }
+                })
+            elif event_destination['TYPE'] == 'sns':
+                sns_topic_name = event_destination['SNS_TOPICS_NAME']
+                region, topic_name = sns_topic_name.split('/')
+                topic_arn = AWSCli(region).get_topic_arn(topic_name)
+
+                ll.append({
+                    "Name": event_destination['NAME'],
+                    "Enabled": event_destination['ENABLED'],
+                    "MatchingEventTypes": event_destination['MATCHING_TYPE'],
+                    "SNSDestination": {
+                        "TopicARN": topic_arn
+                    }
+                })
+
+
+        config['EVENT_DESTINATIONS'] = ll
+
 
         if config_set['NAME'] not in exist_config_names:
             cmd = ['ses', 'create-configuration-set',

--- a/run_create_sns.py
+++ b/run_create_sns.py
@@ -32,7 +32,6 @@ def run_create_sns_topic(name, settings):
         aws_cli.run(cmd)
 
 
-
 ################################################################################
 #
 # start

--- a/run_create_sns.py
+++ b/run_create_sns.py
@@ -23,6 +23,15 @@ def run_create_sns_topic(name, settings):
     result = aws_cli.run(cmd)
     print('created:', result['TopicArn'])
 
+    if 'EMAIL' in settings:
+        print_message('create sns topic(%s) email subscribe' % name)
+        cmd = ['sns', 'subscribe']
+        cmd += ['--topic-arn', result['TopicArn']]
+        cmd += ['--protocol', 'email']
+        cmd += ['--notification-endpoint', settings['EMAIL']]
+        aws_cli.run(cmd)
+
+
 
 ################################################################################
 #

--- a/run_create_sns.py
+++ b/run_create_sns.py
@@ -24,7 +24,7 @@ def run_create_sns_topic(name, settings):
     print('created:', result['TopicArn'])
 
     if 'EMAIL' in settings:
-        print_message('create sns topic(%s) email subscribe' % name)
+        print_message('create an email subscription for sns topic: %s' % name)
         cmd = ['sns', 'subscribe']
         cmd += ['--topic-arn', result['TopicArn']]
         cmd += ['--protocol', 'email']

--- a/run_terminate_sns.py
+++ b/run_terminate_sns.py
@@ -18,9 +18,19 @@ def run_terminate_sns_tpoic(name, settings):
     aws_cli = AWSCli(region)
 
     ################################################################################
-    print_message('terminate sns topic: "%s" in %s' % (name, region))
+    print_message('terminate sns topic subscriptions')
 
     topic_arn = aws_cli.get_topic_arn(name)
+    cmd = ['sns', 'list-subscriptions-by-topic']
+    cmd += ['--topic-arn', topic_arn]
+    rr = aws_cli.run(cmd)
+
+    for ss in rr['Subscriptions']:
+        cmd = ['sns', 'list-subscriptions']
+        cmd += ['--subscription-arn', ss['SubscriptionArn']]
+        aws_cli.run(cmd)
+
+    print_message('terminate sns topic: "%s" in %s' % (name, region))
 
     if not topic_arn:
         return
@@ -28,6 +38,7 @@ def run_terminate_sns_tpoic(name, settings):
     cmd = ['sns', 'delete-topic']
     cmd += ['--topic-arn', topic_arn]
     aws_cli.run(cmd)
+
 
 
 ################################################################################
@@ -38,6 +49,7 @@ def run_terminate_sns_tpoic(name, settings):
 print_session('terminate sns')
 
 sns_list = env.get('sns', list())
+
 for sns_env in sns_list:
     if sns_env['TYPE'] == 'topic':
         run_terminate_sns_tpoic(sns_env['NAME'], sns_env)

--- a/run_terminate_sns.py
+++ b/run_terminate_sns.py
@@ -40,7 +40,6 @@ def run_terminate_sns_tpoic(name, settings):
     aws_cli.run(cmd)
 
 
-
 ################################################################################
 #
 # start

--- a/run_terminate_sns.py
+++ b/run_terminate_sns.py
@@ -21,19 +21,20 @@ def run_terminate_sns_tpoic(name, settings):
     print_message('terminate sns topic subscriptions')
 
     topic_arn = aws_cli.get_topic_arn(name)
+
+    if not topic_arn:
+        return
+
     cmd = ['sns', 'list-subscriptions-by-topic']
     cmd += ['--topic-arn', topic_arn]
     rr = aws_cli.run(cmd)
 
     for ss in rr['Subscriptions']:
-        cmd = ['sns', 'list-subscriptions']
+        cmd = ['sns', 'unsubscribe']
         cmd += ['--subscription-arn', ss['SubscriptionArn']]
         aws_cli.run(cmd)
 
     print_message('terminate sns topic: "%s" in %s' % (name, region))
-
-    if not topic_arn:
-        return
 
     cmd = ['sns', 'delete-topic']
     cmd += ['--topic-arn', topic_arn]


### PR DESCRIPTION
### What is this PR for?
- 이메일 렌더링에 에러 발생시 SNS 에서 이메일 받아 보는 기능 추가
- https://docs.aws.amazon.com/ko_kr/ses/latest/DeveloperGuide/send-personalized-email-api.html

### How should this be tested?
- boto3 로 create_template 로 템플릿을 올리고, send_templated_email 를 통해 메일을 보낼때 템플릿에 parameter 를 빼면 렌더링 에러 발생
- 등록한 메일로 메일 오면 성공
```
"sns": [
  {
      "AWS_DEFAULT_REGION": "us-east-1",
      "NAME": "fail-ses",
      "TYPE": "topic",
      "EMAIL": "<email>"
    }
],
"ses": {
  "CONFIGURATION_SETS": [
      {
        "NAME": "randering-fail",
        "EVENT_DESTINATIONS" : [
          {
            "ENABLED": true,
            "MATCHING_TYPE": ["renderingFailure"],
            "NAME": "RanderingFail",
            "TYPE" : "sns",
            "SNS_TOPICS_NAME": "us-east-1/fail-ses"
          }
        ]
      }
    ]
}
``` 
