### PR TITLE
GEN-6416 fix access parameter default region

### DIFF
--- a/run_create_codebuild_github.py
+++ b/run_create_codebuild_github.py
@@ -15,6 +15,7 @@ def have_parameter_store(settings):
 
 
 def create_iam_for_codebuild(name, settings):
+    aws_default_region = settings.get('AWS_DEFAULT_REGION')
     aws_cli = AWSCli()
 
     nn = name.replace('_', '-')
@@ -71,7 +72,7 @@ def create_iam_for_codebuild(name, settings):
             pp = {
                 'Action': 'ssm:GetParameters',
                 'Effect': 'Allow',
-                'Resource': 'arn:aws:ssm:ap-northeast-2:*:parameter/CodeBuild/*'
+                'Resource': 'arn:aws:ssm:%s:*:parameter/CodeBuild/*' % aws_default_region
             }
             dd['Statement'].append(pp)
 

--- a/run_terminate_codebuild.py
+++ b/run_terminate_codebuild.py
@@ -101,7 +101,7 @@ def run_terminate_github_codebuild(name, settings):
     cmd += ['--project-name', name]
     _aws_cli.run(cmd, ignore_error=True)
 
-    for cc in settings('CRON', list()):
+    for cc in settings.get('CRON', list()):
         rule_name = '%sCronRuleSourceBy%s' % (name, cc['SOURCE_VERSION'].title())
         terminate_cron_event(_aws_cli, rule_name)
 


### PR DESCRIPTION
### What is this PR for?
- codebuild 시 parameter store 를 사용 하는 경우 같은 리전의 parameter store 에 접글 하도록 rule 세팅

### How should this be tested?
- 서울이 아닌 다른 리전에서 parameter store 값을 세팅하고 codebuild 생성후 실행

