### PR TITLE
GEN-7697 appstream iam 생성 및 삭제

### DIFF
--- a/aws_iam/aws-appstream-role.json
+++ b/aws_iam/aws-appstream-role.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "appstream.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/run_create_appstream.py
+++ b/run_create_appstream.py
@@ -253,20 +253,3 @@ if __name__ == "__main__":
         create_stack(stack_name, redirect_url)
         wait_state('fleet', fleet_name, 'RUNNING')
         associate_fleet(stack_name, fleet_name)
-        role_name = 'AWSApplicationAutoscalingAppStreamFleetPolicy'
-
-        aws_cli = AWSCli()
-        if not aws_cli.get_iam_role(role_name):
-            print_message('create iam role')
-
-            cc = ['iam', 'create-role']
-            cc += ['--role-name', role_name]
-            cc += ['--assume-role-policy-document', 'file://aws_iam/aws-appstream-role.json']
-            aws_cli.run(cc)
-
-            cc = ['iam', 'attach-role-policy']
-            cc += ['--role-name', role_name]
-            cc += ['--policy-arn',
-                   'arn:aws:iam::aws:policy/aws-service-role/AWSApplicationAutoscalingAppStreamFleetPolicy']
-            aws_cli.run(cc)
-            sleep_required = True

--- a/run_create_appstream.py
+++ b/run_create_appstream.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 
+import time
 from time import sleep
 
 from env import env
 from run_common import AWSCli
+from run_common import print_message
 from run_common import print_session
 
 
@@ -12,6 +14,47 @@ from run_common import print_session
 # start
 #
 ################################################################################
+def create_iam_for_appstream():
+    aws_cli = AWSCli()
+    sleep_required = False
+
+    role_name = 'AmazonAppStreamServiceAccess'
+    if not aws_cli.get_iam_role(role_name):
+        print_message('create iam role')
+
+        cc = ['iam', 'create-role']
+        cc += ['--role-name', role_name]
+        cc += ['--path', '/service-role/']
+        cc += ['--assume-role-policy-document', 'file://aws_iam/aws-appstream-role.json']
+        aws_cli.run(cc)
+
+        cc = ['iam', 'attach-role-policy']
+        cc += ['--role-name', role_name]
+        cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess']
+        aws_cli.run(cc)
+
+        sleep_required = True
+
+    role_name = 'ApplicationAutoScalingForAmazonAppStreamAccess'
+    if not aws_cli.get_iam_role(role_name):
+        print_message('create iam role')
+
+        cc = ['iam', 'create-role']
+        cc += ['--role-name', role_name]
+        cc += ['--assume-role-policy-document', 'file://aws_iam/aws-appstream-role.json']
+        aws_cli.run(cc)
+
+        cc = ['iam', 'attach-role-policy']
+        cc += ['--role-name', role_name]
+        cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/ApplicationAutoScalingForAmazonAppStreamAccess']
+        aws_cli.run(cc)
+        sleep_required = True
+
+    if sleep_required:
+        print_message('wait 30 seconds to let iam role and policy propagated to all regions...')
+        time.sleep(30)
+
+
 def create_image_builder(name, subnet_id, security_group_id, image_name):
     vpc_config = 'SubnetIds=%s,SecurityGroupIds=%s' % (subnet_id, security_group_id)
 
@@ -182,6 +225,7 @@ if __name__ == "__main__":
     if len(args) > 1:
         target_name = args[1]
 
+    create_iam_for_appstream()
     for env_ib in env['appstream']['IMAGE_BUILDS']:
         if target_name and env_ib['NAME'] != target_name:
             continue
@@ -209,3 +253,20 @@ if __name__ == "__main__":
         create_stack(stack_name, redirect_url)
         wait_state('fleet', fleet_name, 'RUNNING')
         associate_fleet(stack_name, fleet_name)
+        role_name = 'AWSApplicationAutoscalingAppStreamFleetPolicy'
+
+        aws_cli = AWSCli()
+        if not aws_cli.get_iam_role(role_name):
+            print_message('create iam role')
+
+            cc = ['iam', 'create-role']
+            cc += ['--role-name', role_name]
+            cc += ['--assume-role-policy-document', 'file://aws_iam/aws-appstream-role.json']
+            aws_cli.run(cc)
+
+            cc = ['iam', 'attach-role-policy']
+            cc += ['--role-name', role_name]
+            cc += ['--policy-arn',
+                   'arn:aws:iam::aws:policy/aws-service-role/AWSApplicationAutoscalingAppStreamFleetPolicy']
+            aws_cli.run(cc)
+            sleep_required = True

--- a/run_terminate_appstream.py
+++ b/run_terminate_appstream.py
@@ -4,6 +4,7 @@ from time import sleep
 
 from env import env
 from run_common import AWSCli
+from run_common import print_message
 
 
 def delete_fleet(fleet_name):
@@ -11,6 +12,35 @@ def delete_fleet(fleet_name):
     cmd = ['appstream', 'delete-fleet']
     cmd += ['--name', fleet_name]
     return aws_cli.run(cmd, ignore_error=True)
+
+
+def terminate_iam_for_appstream():
+    aws_cli = AWSCli()
+    role_name = 'AmazonAppStreamServiceAccess'
+    print_message('delete iam role')
+
+    # noinspection PyShadowingNames
+    cc = ['iam', 'detach-role-policy']
+    cc += ['--role-name', role_name]
+    cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess']
+    aws_cli.run(cc, ignore_error=True)
+
+    # noinspection PyShadowingNames
+    cc = ['iam', 'delete-role']
+    cc += ['--role-name', role_name]
+    aws_cli.run(cc, ignore_error=True)
+
+    role_name = 'ApplicationAutoScalingForAmazonAppStreamAccess'
+    # noinspection PyShadowingNames
+    cc = ['iam', 'detach-role-policy']
+    cc += ['--role-name', role_name]
+    cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/ApplicationAutoScalingForAmazonAppStreamAccess']
+    aws_cli.run(cc, ignore_error=True)
+
+    # noinspection PyShadowingNames
+    cc = ['iam', 'delete-role']
+    cc += ['--role-name', role_name]
+    aws_cli.run(cc, ignore_error=True)
 
 
 def stop_fleet(fleet_name):
@@ -146,3 +176,5 @@ if __name__ == "__main__":
         stop_fleet(fleet_name)
         wait_state('fleet', fleet_name, 'STOPPED')
         delete_fleet(fleet_name)
+
+    terminate_iam_for_appstream()


### PR DESCRIPTION
### What is this PR for?
- appstream의 image builder, stack을 cli 커멘드로 사용하기 위해서는 필수로 2가지 role을 필요로함. 따라서 해당 role을 추가 및 삭제하는 코드를 추가작업.

### 삽질이 좀 필요했던 부분
1. AWS CLI에서 어떻게 해야 iam을 생성할 수 있는지에 대해서 몰라 여기저기 삽으로 찔러봤습니다.
[ https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-service.html ] 문서에 잘 나와있었는데 나중에 삽질하다가 찾게 됐습니다. ㅠㅠ

2. AWS CLI 에서 role을 생성하기까지 성공을 했는데 builder, stack 생성 시 role을 찾을 수 없다하여 왜 그런지 policy를 GUI로 만들때와 CLI로 만들었을 때 차이를 비교해 보니 iamge builder, stack 및 fleet을 생성할 때 해당 (**AmazonAppStreamServiceAccess**)  Role이 필요한대 , 이 Role은 GUI로 생성할 시 path를 /service-role/ 로 자동 생성해주고 있었습니다. CLI로 생성할 경우는 path 옵션에 service-role로 지정을 해줘야합니다.

3. 처음 이슈 GEN-7697에서 요구했던 사항 중 iam은 총 3개였습니다.
- AmazonAppStreamServiceAccess
- ApplicationAutoScalingForAmazonAppStreamAccess
- AWSServiceRoleForApplicationAutoScaling_AppStreamFleet
첫 번째, 두 번째는 생성이 가능하지만 3번째는 직접 생성이 불가능 했었습니다. 
세 번째의 경우, GUI에서는 compute-capacity를 조정하면 세번 째의 role 생성이 되었는데  CLI에선 compute-capacity를 조정을 하여도 자동으로 생성되진 않았습니다. 추후에  테스트 작업해보며 role에 대해 문제가 나올 경우 재현 가능할 때 추가해도 될 것 같습니다. 

