### PR TITLE
GEN-7979 Add scale option in appstream

### DIFF
--- a/run_create_appstream.py
+++ b/run_create_appstream.py
@@ -112,7 +112,7 @@ def create_stack(stack_name, redirect_url, embed_host_domains):
     cmd += ['--application-settings', application_settings]
     if redirect_url:
         cmd += ['--redirect-url', redirect_url]
-    #cmd += ['--embed-host-domains', embed_host_domains]
+    cmd += ['--embed-host-domains', embed_host_domains]
     aws_cli.run(cmd)
 
 

--- a/run_create_appstream.py
+++ b/run_create_appstream.py
@@ -69,7 +69,7 @@ def create_image_builder(name, subnet_id, security_group_id, image_name):
     aws_cli.run(cmd)
 
 
-def create_fleet(name, image_name, subnet_id, security_group_id):
+def create_fleet(name, image_name, subnet_id, security_group_id, desired_instances):
     vpc_config = 'SubnetIds=%s,SecurityGroupIds=%s' % (subnet_id, security_group_id)
 
     aws_cli = AWSCli()
@@ -77,7 +77,7 @@ def create_fleet(name, image_name, subnet_id, security_group_id):
     cmd += ['--name', name]
     cmd += ['--instance-type', 'stream.standard.medium']
     cmd += ['--fleet-type', 'ON_DEMAND']
-    cmd += ['--compute-capacity', 'DesiredInstances=1']
+    cmd += ['--compute-capacity', 'DesiredInstances=' + str(desired_instances)]
     cmd += ['--image-name', image_name]
     cmd += ['--vpc-config', vpc_config]
     cmd += ['--enable-default-internet-acces']
@@ -112,7 +112,7 @@ def create_stack(stack_name, redirect_url, embed_host_domains):
     cmd += ['--application-settings', application_settings]
     if redirect_url:
         cmd += ['--redirect-url', redirect_url]
-    cmd += ['--embed-host-domains', embed_host_domains]
+    #cmd += ['--embed-host-domains', embed_host_domains]
     aws_cli.run(cmd)
 
 
@@ -251,6 +251,7 @@ if __name__ == "__main__":
         redirect_url = env_s.get('REDIRECT_URL', None)
         stack_name = env_s['NAME']
         embed_host_domains = env_s['EMBED_HOST_DOMAINS']
+        desired_instances = env_s.get('DESIRED_INSTANCES', 1)
 
         create_fleet(fleet_name, image_name, subnet_id, security_group_id)
         create_stack(stack_name, redirect_url, embed_host_domains)


### PR DESCRIPTION
### What is this PR for?
- `AWSServiceRoleForApplicationAutoScaling_AppStreamFleet` 의 권한 없이 scale 가능해 따로 role 작업을 하지 않고 scale 가능을 추가 했습니다.

### How should this be tested?
- config.json 에 appstream 의 naoko-stack 에 `DESIRED_INSTANCES` 옵션을 추가 하고 원하는 값을 넣어 
Maximum capacity 가 해당 값으로 할당 되는지 확인
