### PR TITLE
GEN-7241 Add cloudwatch alarm function for sns

### DIFF
--- a/run_create_cloudwatch_alarm.py
+++ b/run_create_cloudwatch_alarm.py
@@ -231,6 +231,42 @@ def run_create_cloudwatch_alarm_sqs(name, settings):
     aws_cli.run(cmd)
 
 
+def run_create_cloudwatch_alarm_sns(name, settings):
+    phase = env['common']['PHASE']
+    alarm_region = settings['AWS_DEFAULT_REGION']
+    aws_cli = AWSCli(alarm_region)
+
+    alarm_name = '%s-%s_%s_%s' % (phase, name, alarm_region, settings['METRIC_NAME'])
+    print_message('create or update cloudwatch alarm: %s' % alarm_name)
+
+    topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
+    if not topic_arn:
+        print('sns topic: "%s" is not exists in %s' % (settings['SNS_TOPIC_NAME'], alarm_region))
+        raise Exception()
+
+    dimensions = list()
+    for ii in settings['DIMENSIONS']:
+        dd = dict()
+        dd['Name'] = ii['name']
+        dd['Value'] = ii['value']
+        dimensions.append(dd)
+
+    cmd = ['cloudwatch', 'put-metric-alarm']
+    cmd += ['--alarm-actions', topic_arn]
+    cmd += ['--alarm-description', settings['DESCRIPTION']]
+    cmd += ['--alarm-name', alarm_name]
+    cmd += ['--comparison-operator', settings['COMPARISON_OPERATOR']]
+    cmd += ['--datapoints-to-alarm', settings['DATAPOINTS_TO_ALARM']]
+    cmd += ['--dimensions', json.dumps(dimensions)]
+    cmd += ['--evaluation-periods', settings['EVALUATION_PERIODS']]
+    cmd += ['--metric-name', settings['METRIC_NAME']]
+    cmd += ['--namespace', settings['NAMESPACE']]
+    cmd += ['--period', settings['PERIOD']]
+    cmd += ['--statistic', settings['STATISTIC']]
+    cmd += ['--threshold', settings['THRESHOLD']]
+    aws_cli.run(cmd)
+
+
 ################################################################################
 #
 # start
@@ -267,6 +303,8 @@ for cw_alarm_env in cw.get('ALARMS', list()):
         run_create_cloudwatch_alarm_sqs(cw_alarm_env['NAME'], cw_alarm_env)
     elif cw_alarm_env['TYPE'] == 'lambda':
         run_create_cloudwatch_alarm_lambda(cw_alarm_env['NAME'], cw_alarm_env)
+    elif cw_alarm_env['TYPE'] == 'sns':
+        run_create_cloudwatch_alarm_sns(cw_alarm_env['NAME'], cw_alarm_env)
     else:
         print('"%s" is not supported' % cw_alarm_env['TYPE'])
         raise Exception()


### PR DESCRIPTION
### What is this PR for?
- SMS 실패및 전송 개수에 대한 Alarm을 추가하기 위한 함수 추가

### How should this be tested?
- magi로부터 새롭게 config파일 생성
- `./run_create_cloudwatch_alarm.py sns_failed`

`magi`
https://github.com/HardBoiledSmith/magi/pull/516
