### PR TITLE
GEN-7085 Add cloudfront and route53

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ You can use this on web GUI
 
 * [raynor](https://github.com/HardBoiledSmith/raynor) is web based GUI for johanna
 
+# Script to create cloudfront and route 53
+- Execute `run_create_cloudfront.py` to create cloud front
+```bash
+./run_create_cloudfront.py -b <s3 bucket name> -e <s3 bucket end point> -a <acm-arn> -c <cname> -f
+```
+- Execute `run_create_cloudfront.py` to create route53
+- reference HOSTED_ZONE_ID : https://docs.aws.amazon.com/Route53/latest/APIReference/API_AliasTarget.html#Route53-Type-AliasTarget-HostedZoneIdx
+```bash
+./run_create_route53.py -ah Z2FDTNDATAQYW2 -at cloudfront -d <cloudfront domain name> -hn hbsmith.io -n <domain> -r A -f
+```
+
 # Notes
 
 * If you use AWS IAM user credential instead of master account, it must have IAMFullAccess, AWSElasticBeanstalkFullAccess and PowerUserAccess permissions.

--- a/run_create_cloudfront.py
+++ b/run_create_cloudfront.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+import json
+from argparse import ArgumentParser
+
+from run_common import AWSCli
+from run_common import _confirm_phase
+from run_common import print_message
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('-f', '--force', action='store_true', help='pass confirm')
+    parser.add_argument('-b', '--backet', type=str, required=True, help='static web bucket name')
+    parser.add_argument('-e', '--endpoint', type=str, required=True, help='s3 bucket end point')
+    parser.add_argument('-a', '--acm-arn', dest='acm_arn', type=str, required=True, help='acm arn')
+    parser.add_argument('-c', '--cname', type=str, required=True, nargs='+', help='cname')
+
+    args = parser.parse_args()
+
+    if not args.force:
+        _confirm_phase()
+
+    return args
+
+
+def is_exist_cname(cname_list):
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'list-distributions']
+    rr = aws_cli.run(cmd)
+
+    for vv in rr['DistributionList']['Items']:
+        for cc in cname_list:
+            if 'Items' in vv['Aliases'] and cc in vv['Aliases']['Items']:
+                print_message('exist cname(%s)' % cc)
+                return True
+
+    return False
+
+
+def create_cloudfront(bucket_name, origin_url, certificate_arn, cname_list):
+    origin_id = 'S3-Website-%s' % bucket_name
+
+    dd = dict()
+    dd['PriceClass'] = 'PriceClass_200'
+    dd['CallerReference'] = bucket_name
+    dd['Comment'] = ''
+    dd['Enabled'] = True
+
+    dd['Aliases'] = {
+        'Quantity': len(cname_list),
+        'Items': cname_list
+    }
+
+    dd['Origins'] = {
+        'Quantity': 1,
+        'Items': [
+            {
+                'Id': origin_id,
+                'DomainName': origin_url,
+                'CustomOriginConfig': {
+                    'HTTPPort': 80,
+                    'HTTPSPort': 443,
+                    'OriginProtocolPolicy': 'http-only',
+                    'OriginSslProtocols': {
+                        'Items': [
+                            'TLSv1',
+                            'TLSv1.1',
+                            'TLSv1.2'
+                        ],
+                        'Quantity': 3
+                    }
+                }
+            }
+        ]
+    }
+
+    dd['DefaultCacheBehavior'] = {
+        'TargetOriginId': origin_id,
+        'ViewerProtocolPolicy': 'redirect-to-https',
+        'AllowedMethods': {
+            'CachedMethods': {
+                'Items': ['HEAD', 'GET'],
+                'Quantity': 2
+            },
+            'Items': ['HEAD', 'GET'],
+            'Quantity': 2
+        },
+        'Compress': False,
+        'ForwardedValues': {
+            'QueryString': False,
+            'Cookies': {
+                'Forward': 'none'
+            },
+            'Headers': {
+                'Quantity': 0
+            },
+            'QueryStringCacheKeys': {
+                'Quantity': 0
+            }
+        },
+        'TrustedSigners': {
+            'Enabled': False,
+            'Quantity': 0
+        },
+        "MinTTL": 0,
+        "DefaultTTL": 86400,
+        "MaxTTL": 31536000
+    }
+
+    dd['ViewerCertificate'] = {
+        'ACMCertificateArn': certificate_arn,
+        'Certificate': certificate_arn,
+        'CertificateSource': 'acm',
+        'MinimumProtocolVersion': 'TLSv1.1_2016',
+        'SSLSupportMethod': 'sni-only'
+    }
+
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'create-distribution']
+    cmd += ['--distribution-config', json.dumps(dd)]
+    rr = aws_cli.run(cmd)
+    return rr
+
+
+def create_route53(name, type, dns_name, alias_hostzon_id):
+    rrs = dict()
+    if alias_hostzon_id:
+        rrs = {
+            "Name": name,
+            "Type": type,
+            "AliasTarget": {
+                "HostedZoneId": alias_hostzon_id,
+                "DNSName": dns_name,
+                "EvaluateTargetHealth": False
+            }
+        }
+    else:
+        rrs = {
+            "Name": name,
+            "Type": type,
+            "ResourceRecord": [
+                {
+                    "Value": dns_name
+                }
+            ]
+        }
+
+    dd = dict()
+    dd['Changes'] = [
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet": rrs
+        }
+    ]
+
+    aws_cli = AWSCli()
+    cmd = ['route53', 'change-resource-record-sets']
+    cmd += ['--change-batch', json.dumps(dd)]
+    rr = aws_cli.run(cmd)
+    return rr
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    bucket_name = args.backet
+    origin_domain_name = args.endpoint
+    certificate_arn = args.acm_arn
+    cname_list = args.cname
+
+    if is_exist_cname(cname_list):
+        exit(1)
+
+    create_cloudfront(bucket_name, origin_domain_name, certificate_arn, cname_list)

--- a/run_create_cloudfront.py
+++ b/run_create_cloudfront.py
@@ -16,7 +16,7 @@ from run_common import print_message
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument('-f', '--force', action='store_true', help='pass confirm')
-    parser.add_argument('-b', '--backet', type=str, required=True, help='static web bucket name')
+    parser.add_argument('-b', '--bucket', type=str, required=True, help='s3 bucket name')
     parser.add_argument('-e', '--endpoint', type=str, required=True, help='s3 bucket end point')
     parser.add_argument('-a', '--acm-arn', dest='acm_arn', type=str, required=True, help='acm arn')
     parser.add_argument('-c', '--cname', type=str, required=True, nargs='+', help='cname')
@@ -168,7 +168,7 @@ def create_route53(name, type, dns_name, alias_hostzon_id):
 
 if __name__ == '__main__':
     args = parse_args()
-    bucket_name = args.backet
+    bucket_name = args.bucket
     origin_domain_name = args.endpoint
     certificate_arn = args.acm_arn
     cname_list = args.cname

--- a/run_create_route53.py
+++ b/run_create_route53.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+import json
+from argparse import ArgumentParser
+
+from run_common import AWSCli
+from run_common import _confirm_phase
+from run_common import print_session
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('-f', '--force', action='store_true', help='pass confirm')
+    parser.add_argument('-ah', '--alias_hosted_zone_id', type=str, required=False, help='hosted zone id of alias')
+    parser.add_argument('-at', '--alias_type', type=str, required=False, choices=['cloudfront', 's3'],
+                        help='type of alias')
+    parser.add_argument('-d', '--domain_name', type=str, required=True,
+                        help='domain name(s3 -> end point, cloudfront -> domain name)')
+    parser.add_argument('-hn', '--hosted_zone_name', type=str, required=True, help='name of hosted zone')
+    parser.add_argument('-n', '--name', type=str, required=True, help='acm arn')
+    parser.add_argument('-r', '--record_set_type', type=str, required=True, help='type of record_set')
+
+    args = parser.parse_args()
+
+    if not args.force:
+        _confirm_phase()
+
+    return args
+
+
+def is_exist_record_set(host_zone_name, name):
+    print_session('is_exist_record_set')
+    aws_cli = AWSCli()
+    cmd = ['route53', 'list-hosted-zones-by-name']
+    cmd += ['--dns-name', host_zone_name]
+    rr = aws_cli.run(cmd)
+
+    if not (len(rr['HostedZones']) == 1):
+        raise Exception('wrong host zone')
+
+    hosted_zone_id = rr['HostedZones'][0]['Id']
+
+    cmd = ['route53', 'list-resource-record-sets']
+    cmd += ['--hosted-zone-id', hosted_zone_id]
+    rr = aws_cli.run(cmd)
+
+    for vv in rr['ResourceRecordSets']:
+        if vv['Name'] == name:
+            print_session('exist record set(%s)' % name)
+            return True
+
+    return False
+
+
+def find_host_zone_id(host_zone_name):
+    print_session('find_host_zone_id')
+    aws_cli = AWSCli()
+    cmd = ['route53', 'list-hosted-zones-by-name']
+    cmd += ['--dns-name', host_zone_name]
+    rr = aws_cli.run(cmd)
+
+    if not (len(rr['HostedZones']) == 1):
+        raise Exception('wrong host zone')
+
+    return rr['HostedZones'][0]['Id']
+
+
+def find_cloudfront(domain_name):
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'list-distributions']
+    rr = aws_cli.run(cmd)
+
+    for vv in rr['DistributionList']['Items']:
+        if 'Items' in vv['Aliases'] and domain_name in vv['Aliases']['Items']:
+            return vv
+
+
+def create_route53(name, host_zone_name, type, domain_name, alias=None):
+    rrs = dict()
+    if alias:
+        if alias['TYPE'] == 'cloudfront':
+            rr = find_cloudfront(domain_name)
+            domain_name = rr['DomainName']
+
+        rrs = {
+            "Name": name,
+            "Type": type,
+            "AliasTarget": {
+                "HostedZoneId": alias['HOSTED_ZONE_ID'],
+                "DNSName": domain_name,
+                "EvaluateTargetHealth": False
+            }
+        }
+    else:
+        rrs = {
+            "Name": name,
+            "Type": type,
+            "ResourceRecord": [
+                {
+                    "Value": domain_name
+                }
+            ]
+        }
+
+    dd = dict()
+    dd['Changes'] = [
+        {
+            "Action": "CREATE",
+            "ResourceRecordSet": rrs
+        }
+    ]
+
+    aws_cli = AWSCli()
+    cmd = ['route53', 'change-resource-record-sets']
+    id = find_host_zone_id(host_zone_name)
+    cmd += ['--hosted-zone-id', id]
+    cmd += ['--change-batch', json.dumps(dd)]
+    rr = aws_cli.run(cmd)
+    return rr
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    hosted_zone_name = args.hosted_zone_name
+    name = args.name
+    record_set_type = args.record_set_type
+    domain_name = args.domain_name
+    alias_hosted_zone_id = args.alias_hosted_zone_id
+    alias_type = args.alias_type
+
+    alias = None
+    if alias_type:
+        alias = dict()
+        alias['TYPE'] = alias_type
+        alias['HOSTED_ZONE_ID'] = alias_hosted_zone_id
+
+    if is_exist_record_set(hosted_zone_name, name):
+        exit(1)
+
+    create_route53(name, hosted_zone_name, record_set_type, domain_name, alias)

--- a/run_terminate_cloudfront.py
+++ b/run_terminate_cloudfront.py
@@ -52,7 +52,7 @@ def disable_cloudfront(id):
     rr = aws_cli.run(cmd)
     e_tag = rr['ETag']
 
-    if rr['Distribution']['DistributionConfig']['Enabled'] == False:
+    if not rr['Distribution']['DistributionConfig']['Enabled']:
         return
 
     aws_cli = AWSCli()
@@ -106,8 +106,8 @@ if __name__ == "__main__":
     args = parse_args()
     domain_name = args.cname
 
-    cc = re.split('-|\.', domain_name)
-    if not 'dv' in cc:
+    cc = re.split('[-.]', domain_name)
+    if 'dv' not in cc:
         print('only can delete dv')
         exit(1)
 

--- a/run_terminate_cloudfront.py
+++ b/run_terminate_cloudfront.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+import json
+import re
+from argparse import ArgumentParser
+from time import sleep
+
+from run_common import AWSCli
+from run_common import _confirm_phase
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('-f', '--force', action='store_true', help='pass confirm')
+    parser.add_argument('-c', '--cname', type=str, required=True, help='cname')
+
+    args = parser.parse_args()
+
+    if not args.force:
+        _confirm_phase()
+
+    return args
+
+
+def find_cloudfront(domain_name):
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'list-distributions']
+    rr = aws_cli.run(cmd)
+
+    for vv in rr['DistributionList']['Items']:
+        if 'Items' in vv['Aliases'] and domain_name in vv['Aliases']['Items']:
+            return vv
+
+
+def delete_cloudfront(id):
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'get-distribution']
+    cmd += ['--id', id]
+    rr = aws_cli.run(cmd)
+    e_tag = rr['ETag']
+
+    cmd = ['cloudfront', 'delete-distribution']
+    cmd += ['--id', id]
+    cmd += ['--if-match', e_tag]
+    rr = aws_cli.run(cmd)
+
+
+def disable_cloudfront(id):
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'get-distribution']
+    cmd += ['--id', id]
+    rr = aws_cli.run(cmd)
+    e_tag = rr['ETag']
+
+    if rr['Distribution']['DistributionConfig']['Enabled'] == False:
+        return
+
+    aws_cli = AWSCli()
+    cmd = ['cloudfront', 'update-distribution']
+    cmd += ['--id', id]
+    cmd += ['--if-match', e_tag]
+    dd = dict()
+    dd['PriceClass'] = 'PriceClass_200'
+    dd['CallerReference'] = domain_name
+    dd['Origins'] = rr['Distribution']['DistributionConfig']['Origins']
+    dd['DefaultCacheBehavior'] = rr['Distribution']['DistributionConfig']['DefaultCacheBehavior']
+    dd['DefaultRootObject'] = rr['Distribution']['DistributionConfig']['DefaultRootObject']
+    dd['Comment'] = rr['Distribution']['DistributionConfig']['Comment']
+    dd['Aliases'] = rr['Distribution']['DistributionConfig']['Aliases']
+    dd['Enabled'] = False
+    rr['Distribution']['DistributionConfig']['Enabled'] = False
+    cmd += ['--distribution-config', json.dumps(rr['Distribution']['DistributionConfig'])]
+    aws_cli.run(cmd)
+
+
+def wait_cloudfront_status(id, status):
+    aws_cli = AWSCli()
+    elapsed_time = 0
+    is_not_terminate = True
+
+    while is_not_terminate:
+        cmd = ['cloudfront', 'get-distribution']
+        cmd += ['--id', id]
+        rr = aws_cli.run(cmd)
+
+        ss = rr['Distribution']['Status']
+        if status == ss:
+            is_not_terminate = False
+
+        if elapsed_time > 1200:
+            raise Exception('timeout: stop cloudfront(%s)' % id)
+
+        sleep(5)
+        print('wait cloudfront status(%s), but now %s (elapsed time: \'%d\' seconds)' % (status, ss, elapsed_time))
+        elapsed_time += 5
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    domain_name = args.cname
+
+    cc = re.split('-|\.', domain_name)
+    if not 'dv' in cc:
+        print('only can delete dv')
+        exit(1)
+
+    cc = find_cloudfront(domain_name)
+    id = cc['Id']
+
+    disable_cloudfront(id)
+    wait_cloudfront_status(id, 'Deployed')
+    delete_cloudfront(id)

--- a/run_terminate_route53.py
+++ b/run_terminate_route53.py
@@ -76,8 +76,8 @@ if __name__ == "__main__":
     hosted_zone_name = args.hosted_zone_name
     name = args.name
 
-    cc = re.split('-|\.', name)
-    if not 'dv' in cc:
+    cc = re.split('[-.]', name)
+    if 'dv' not in cc:
         print('only can delete dv')
         exit(1)
 

--- a/run_terminate_route53.py
+++ b/run_terminate_route53.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import json
+import re
+from argparse import ArgumentParser
+
+from run_common import AWSCli
+from run_common import _confirm_phase
+from run_common import print_session
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument('-f', '--force', action='store_true', help='pass confirm')
+    parser.add_argument('-hn', '--hosted_zone_name', type=str, required=True, help='name of hosted zone')
+    parser.add_argument('-n', '--name', type=str, required=True, help='acm arn')
+
+    args = parser.parse_args()
+
+    if not args.force:
+        _confirm_phase()
+
+    return args
+
+
+def find_host_zone_id(host_zone_name):
+    print_session('find_host_zone_id')
+    aws_cli = AWSCli()
+    cmd = ['route53', 'list-hosted-zones-by-name']
+    cmd += ['--dns-name', host_zone_name]
+    rr = aws_cli.run(cmd)
+
+    if not (len(rr['HostedZones']) == 1):
+        raise Exception('wrong host zone')
+
+    return rr['HostedZones'][0]['Id']
+
+
+def delete_route53(name, host_zone_name):
+    id = find_host_zone_id(host_zone_name)
+
+    aws_cli = AWSCli()
+    cmd = ['route53', 'list-resource-record-sets']
+    cmd += ['--hosted-zone-id', id]
+    rr = aws_cli.run(cmd)
+
+    for rrs in rr['ResourceRecordSets']:
+        if rrs['Name'] == name + '.':
+            dd = dict()
+            dd['Changes'] = [
+                {
+                    "Action": "DELETE",
+                    "ResourceRecordSet": rrs
+                }
+            ]
+
+            aws_cli = AWSCli()
+            cmd = ['route53', 'change-resource-record-sets']
+            id = find_host_zone_id(host_zone_name)
+            cmd += ['--hosted-zone-id', id]
+            cmd += ['--change-batch', json.dumps(dd)]
+            rr = aws_cli.run(cmd)
+            print(rr)
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    hosted_zone_name = args.hosted_zone_name
+    name = args.name
+
+    cc = re.split('-|\.', name)
+    if not 'dv' in cc:
+        print('only can delete dv')
+        exit(1)
+
+    delete_route53(name, hosted_zone_name)


### PR DESCRIPTION
### What is this PR for?
- cloudfront(cdn)과 route53(dns) 생성하고 삭제 할 수 있는 스크립트 추가
- config.json 파일에 access key 와 scret key 를 의존 하고 나머지 설정을 args 로 받아 처리
- 삭제시에는 dv 가 포함 되지 않은 도메인은 실행 되지 않도록 작성

### How should this be tested?
- test web 를 위한 cloud front 와 route53 설정을 진행하면 좋음
- `./run_create_cloudfront.py -b <s3 bucket name> -e <s3 bucket end point> -a <acm-arn> -c <cname> -f` 로 생성
  - 예 : `./run_create_cloudfront.py -b hyeonku-dv-test.hbsmith.io -e hyeonku-dv-test.hbsmith.io.s3-website.ap-northeast-2.amazonaws.com -a arn:aws:acm:us-east-1:...:certificate/... -c hyeonku-dv-test.hbsmith.io -f`
- `./run_create_route53.py -ah Z2FDTNDATAQYW2 -at cloudfront -d <cloudfront domain name> -hn hbsmith.io -n <domain> -r A -f` 로 생성
  - 예 : `./run_create_route53.py -ah Z2FDTNDATAQYW2 -at cloudfront -d hyeonku-dv-test.hbsmith.io -hn hbsmith.io -n hyeonku-dv-test.hbsmith.io -r A -f`
- `./run_terminate_cloudfront.py -c <cname> -f` 로 삭제
  - 예 : `./run_terminate_cloudfront.py -c hyeonku-dv-test.hbsmith.io -f`
- `./run_terminate_route53.py -n <domain> -hn hbsmith.io -f` 로 삭제
  - 예 : `./run_terminate_route53.py -n hyeonku-dv-test.hbsmith.io -hn hbsmith.io -f`


