### PR TITLE
GEN-8254 run_create_appstream builder, stack&fleet 코드 분리

### DIFF
--- a/run_create_appstream_builder.py
+++ b/run_create_appstream_builder.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+import time
+from time import sleep
+
+from env import env
+from run_common import AWSCli
+from run_common import print_message
+from run_common import print_session
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+def create_iam_for_appstream():
+    aws_cli = AWSCli()
+    sleep_required = False
+
+    role_name = 'AmazonAppStreamServiceAccess'
+    if not aws_cli.get_iam_role(role_name):
+        print_message('create iam role: %s' % role_name)
+
+        cc = ['iam', 'create-role']
+        cc += ['--role-name', role_name]
+        cc += ['--path', '/service-role/']
+        cc += ['--assume-role-policy-document', 'file://aws_iam/aws-appstream-role.json']
+        aws_cli.run(cc)
+
+        cc = ['iam', 'attach-role-policy']
+        cc += ['--role-name', role_name]
+        cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess']
+        aws_cli.run(cc)
+
+        sleep_required = True
+
+    role_name = 'ApplicationAutoScalingForAmazonAppStreamAccess'
+    if not aws_cli.get_iam_role(role_name):
+        print_message('create iam role: %s' % role_name)
+
+        cc = ['iam', 'create-role']
+        cc += ['--role-name', role_name]
+        cc += ['--assume-role-policy-document', 'file://aws_iam/aws-appstream-role.json']
+        aws_cli.run(cc)
+
+        cc = ['iam', 'attach-role-policy']
+        cc += ['--role-name', role_name]
+        cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/ApplicationAutoScalingForAmazonAppStreamAccess']
+        aws_cli.run(cc)
+        sleep_required = True
+
+    if sleep_required:
+        print_message('wait 30 seconds to let iam role and policy propagated to all regions...')
+        time.sleep(30)
+
+
+def create_image_builder(name, subnet_ids, security_group_id, image_name):
+    vpc_config = 'SubnetIds=%s,SecurityGroupIds=%s' % (subnet_ids, security_group_id)
+
+    aws_cli = AWSCli()
+    cmd = ['appstream', 'create-image-builder']
+    cmd += ['--name', name]
+    cmd += ['--instance-type', 'stream.standard.medium']
+    cmd += ['--image-name', image_name]
+    cmd += ['--vpc-config', vpc_config]
+    cmd += ['--no-enable-default-internet-access']
+
+    aws_cli.run(cmd)
+
+
+def wait_state(service, name, state):
+    services = {
+        'image-builder': {
+            'cmd': 'describe-image-builders',
+            'name': 'ImageBuilders'
+        },
+        'fleet': {
+            'cmd': 'describe-fleets',
+            'name': 'Fleets'
+        }
+    }
+
+    if service not in services:
+        raise Exception('only allow services(%s)' % ', '.join(services.keys()))
+
+    aws_cli = AWSCli()
+    elapsed_time = 0
+    is_not_terminate = True
+    ss = services[service]
+
+    while is_not_terminate:
+        cmd = ['appstream', ss['cmd']]
+        cmd += ['--name', name]
+        rr = aws_cli.run(cmd)
+
+        for r in rr[ss['name']]:
+            if state == r['State']:
+                is_not_terminate = False
+
+        if elapsed_time > 1200:
+            raise Exception('timeout: stop appstream image builder(%s)' % name)
+
+        sleep(5)
+        print('wait image builder state(%s) (elapsed time: \'%d\' seconds)' % (state, elapsed_time))
+        elapsed_time += 5
+
+
+def get_subnet_and_security_group_id():
+    aws_cli = AWSCli()
+    cidr_subnet = aws_cli.cidr_subnet
+
+    print_message('get vpc id')
+
+    rds_vpc_id, eb_vpc_id = aws_cli.get_vpc_id()
+
+    if not eb_vpc_id:
+        print('ERROR!!! No VPC found')
+        raise Exception()
+
+    print_message('get subnet id')
+
+    subnet_id_1 = None
+    subnet_id_2 = None
+    cmd = ['ec2', 'describe-subnets']
+    rr = aws_cli.run(cmd)
+    for r in rr['Subnets']:
+        if r['VpcId'] != eb_vpc_id:
+            continue
+        if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
+            subnet_id_1 = r['SubnetId']
+        if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
+            subnet_id_2 = r['SubnetId']
+
+    print_message('get security group id')
+
+    security_group_id = None
+    cmd = ['ec2', 'describe-security-groups']
+    rr = aws_cli.run(cmd)
+    for r in rr['SecurityGroups']:
+        if r['VpcId'] != eb_vpc_id:
+            continue
+        if r['GroupName'] == '%seb_private' % name_prefix:
+            security_group_id = r['GroupId']
+            break
+
+    return [subnet_id_1, subnet_id_2], security_group_id
+
+
+if __name__ == "__main__":
+    from run_common import parse_args
+
+    args = parse_args()
+
+    target_name = None
+    service_name = env['common'].get('SERVICE_NAME', '')
+    name_prefix = '%s_' % service_name if service_name else ''
+    subnet_ids, security_group_id = get_subnet_and_security_group_id()
+
+    if len(args) > 1:
+        target_name = args[1]
+
+    create_iam_for_appstream()
+    for env_ib in env['appstream']['IMAGE_BUILDS']:
+        if target_name and env_ib['NAME'] != target_name:
+            continue
+
+        print_session('create appstream image builder')
+
+        name = env_ib['NAME']
+        image_name = env_ib['IMAGE_NAME']
+
+        create_image_builder(name, subnet_ids[0], security_group_id, image_name)
+        wait_state('image-builder', name, 'RUNNING')

--- a/run_terminate_appstream_builder.py
+++ b/run_terminate_appstream_builder.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+from time import sleep
+
+from env import env
+from run_common import AWSCli
+from run_common import print_message
+
+
+def terminate_iam_for_appstream():
+    aws_cli = AWSCli()
+    role_name = 'AmazonAppStreamServiceAccess'
+    print_message('delete iam role')
+
+    # noinspection PyShadowingNames
+    cc = ['iam', 'detach-role-policy']
+    cc += ['--role-name', role_name]
+    cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess']
+    aws_cli.run(cc, ignore_error=True)
+
+    # noinspection PyShadowingNames
+    cc = ['iam', 'delete-role']
+    cc += ['--role-name', role_name]
+    aws_cli.run(cc, ignore_error=True)
+
+    role_name = 'ApplicationAutoScalingForAmazonAppStreamAccess'
+    # noinspection PyShadowingNames
+    cc = ['iam', 'detach-role-policy']
+    cc += ['--role-name', role_name]
+    cc += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/ApplicationAutoScalingForAmazonAppStreamAccess']
+    aws_cli.run(cc, ignore_error=True)
+
+    # noinspection PyShadowingNames
+    cc = ['iam', 'delete-role']
+    cc += ['--role-name', role_name]
+    aws_cli.run(cc, ignore_error=True)
+
+
+def delete_image(image_name):
+    aws_cli = AWSCli()
+    cmd = ['appstream', 'delete-image']
+    cmd += ['--name', image_name]
+    aws_cli.run(cmd, ignore_error=True)
+
+
+def delete_image_builder(image_build_name):
+    aws_cli = AWSCli()
+    cmd = ['appstream', 'delete-image-builder']
+    cmd += ['--name', image_build_name]
+    aws_cli.run(cmd, ignore_error=True)
+
+
+def stop_image_builder(name):
+    aws_cli = AWSCli()
+    cmd = ['appstream', 'stop-image-builder']
+    cmd += ['--name', name]
+    aws_cli.run(cmd, ignore_error=True)
+
+
+def exist_image_builder(name):
+    aws_cli = AWSCli()
+    cmd = ['appstream', 'describe-image-builders']
+    cmd += ['--name', name]
+
+    rr = aws_cli.run(cmd, ignore_error=True)
+    return bool(rr)
+
+
+def wait_state(service, name, state):
+    services = {
+        'image-builder': {
+            'cmd': 'describe-image-builders',
+            'name': 'ImageBuilders'
+        },
+        'fleet': {
+            'cmd': 'describe-fleets',
+            'name': 'Fleets'
+        }
+    }
+
+    if service not in services:
+        raise Exception('only allow services(%s)' % ', '.join(services.keys()))
+
+    aws_cli = AWSCli()
+    elapsed_time = 0
+    is_not_terminate = True
+    ss = services[service]
+
+    while is_not_terminate:
+        cmd = ['appstream', ss['cmd']]
+        cmd += ['--name', name]
+        rr = aws_cli.run(cmd)
+
+        for r in rr[ss['name']]:
+            if state == r['State']:
+                is_not_terminate = False
+
+        if elapsed_time > 1200:
+            raise Exception('timeout: stop appstream image builder(%s)' % name)
+
+        sleep(5)
+        print('wait image builder state(%s) (elapsed time: \'%d\' seconds)' % (state, elapsed_time))
+        elapsed_time += 5
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+
+
+if __name__ == "__main__":
+    from run_common import parse_args
+
+    args = parse_args()
+
+    target_name = None
+
+    if len(args) > 1:
+        target_name = args[1]
+
+    for env_ib in env['appstream']['IMAGE_BUILDS']:
+        image_builder_name = env_ib['NAME']
+        if target_name and image_builder_name != target_name:
+            continue
+
+        if not exist_image_builder(image_builder_name):
+            continue
+
+        stop_image_builder(image_builder_name)
+        wait_state('image-builder', image_builder_name, 'STOPPED')
+        delete_image_builder(image_builder_name)
+
+    terminate_iam_for_appstream()

--- a/run_terminate_appstream_stack_fleet.py
+++ b/run_terminate_appstream_stack_fleet.py
@@ -7,13 +7,6 @@ from run_common import AWSCli
 from run_common import print_message
 
 
-def delete_fleet(fleet_name):
-    aws_cli = AWSCli()
-    cmd = ['appstream', 'delete-fleet']
-    cmd += ['--name', fleet_name]
-    return aws_cli.run(cmd, ignore_error=True)
-
-
 def terminate_iam_for_appstream():
     aws_cli = AWSCli()
     role_name = 'AmazonAppStreamServiceAccess'
@@ -50,41 +43,18 @@ def stop_fleet(fleet_name):
     aws_cli.run(cmd, ignore_error=True)
 
 
+def delete_fleet(fleet_name):
+    aws_cli = AWSCli()
+    cmd = ['appstream', 'delete-fleet']
+    cmd += ['--name', fleet_name]
+    return aws_cli.run(cmd, ignore_error=True)
+
+
 def delete_stack(stack_name):
     aws_cli = AWSCli()
     cmd = ['appstream', 'delete-stack']
     cmd += ['--name', stack_name]
     return aws_cli.run(cmd, ignore_error=True)
-
-
-def delete_image(image_name):
-    aws_cli = AWSCli()
-    cmd = ['appstream', 'delete-image']
-    cmd += ['--name', image_name]
-    aws_cli.run(cmd, ignore_error=True)
-
-
-def delete_image_builder(image_build_name):
-    aws_cli = AWSCli()
-    cmd = ['appstream', 'delete-image-builder']
-    cmd += ['--name', image_build_name]
-    aws_cli.run(cmd, ignore_error=True)
-
-
-def stop_image_builder(name):
-    aws_cli = AWSCli()
-    cmd = ['appstream', 'stop-image-builder']
-    cmd += ['--name', name]
-    aws_cli.run(cmd, ignore_error=True)
-
-
-def exist_image_builder(name):
-    aws_cli = AWSCli()
-    cmd = ['appstream', 'describe-image-builders']
-    cmd += ['--name', name]
-
-    rr = aws_cli.run(cmd, ignore_error=True)
-    return bool(rr)
 
 
 def disassociate_fleet(fleet_name, stack_name):
@@ -150,18 +120,6 @@ if __name__ == "__main__":
 
     if len(args) > 1:
         target_name = args[1]
-
-    for env_ib in env['appstream']['IMAGE_BUILDS']:
-        image_builder_name = env_ib['NAME']
-        if target_name and image_builder_name != target_name:
-            continue
-
-        if not exist_image_builder(image_builder_name):
-            continue
-
-        stop_image_builder(image_builder_name)
-        wait_state('image-builder', image_builder_name, 'STOPPED')
-        delete_image_builder(image_builder_name)
 
     for env_s in env['appstream']['STACK']:
         if target_name and env_s['NAME'] != target_name:


### PR DESCRIPTION
### What is this PR for?
기존에 만들어진 image가 없는 상태에서 run_create_appstream 하면 builder 생성후 stack/fleet을 바로 생성하지 못해 죽음
1의 상황때문에 이미지를 build 해놓고 다시 run_create_appstream 하면 이미 builder가 만들어져있는 상태라 exception 발생
2의 상황 때문에 builder 생성 로직을 주석처리해서 무시해도 fleet/stack에서 에러가 발생하여 생성이 안됨
 제안: builder 생성과 stack/fleet 생성을 서로다른 run_* 로 분리할 필요 있음 (run_create_appstream_builder.py, run_create_appstream_stack_fleet.py)

### How should this be tested?
1.  johanna에서 ./run_create_appstream_builder.py 를 실행 하여 이미지 빌더가 뜨면 이미지를 생성해 주세요
2. 이미지 생성이 완료되면 ./run_create_appstream_stack_fleet.py을 실행해 주세요
3. 테스트 이후에는 생성한 terminate 시켜주시기 바랍니다