### PR TITLE
GEN-8512 appstream embed stack redirct url 제거

### DIFF
--- a/run_create_appstream_stack_fleet.py
+++ b/run_create_appstream_stack_fleet.py
@@ -77,7 +77,7 @@ def create_fleet(name, image_name, subnet_ids, security_group_id, desired_instan
     aws_cli.run(cmd)
 
 
-def create_stack(stack_name, redirect_url, embed_host_domains):
+def create_stack(stack_name, embed_host_domains):
     name = stack_name
 
     storage_connectors = 'ConnectorType=HOMEFOLDERS,'
@@ -96,8 +96,6 @@ def create_stack(stack_name, redirect_url, embed_host_domains):
     # cmd += ['--storage-connectors', storage_connectors]
     cmd += ['--user-settings', user_settings]
     cmd += ['--application-settings', application_settings]
-    if redirect_url:
-        cmd += ['--redirect-url', redirect_url]
     cmd += ['--embed-host-domains', embed_host_domains]
     aws_cli.run(cmd)
 
@@ -210,12 +208,11 @@ if __name__ == "__main__":
 
         fleet_name = env_s['FLEET_NAME']
         image_name = env_s['IMAGE_NAME']
-        redirect_url = env_s.get('REDIRECT_URL', None)
         stack_name = env_s['NAME']
         embed_host_domains = env_s['EMBED_HOST_DOMAINS']
         desired_instances = env_s.get('DESIRED_INSTANCES', 1)
 
         create_fleet(fleet_name, image_name, ','.join(subnet_ids), security_group_id, desired_instances)
-        create_stack(stack_name, redirect_url, embed_host_domains)
+        create_stack(stack_name, embed_host_domains)
         wait_state('fleet', fleet_name, 'RUNNING')
         associate_fleet(stack_name, fleet_name)


### PR DESCRIPTION
### What is this PR for?
- web에서 modal창을 사용함으로 인해 redirct_url 옵션이 필요없어져 제거하였습니다.

### How should this be tested?
- stack및 fleet이 뜬 후에 redirect url 설정이 들어가 있는지 확인해야 합니다.

### 요청사항
confing.json에서 STACK 의 파라미터 중 REDIRECT_URL 값을 지워야합니다.
