### PR TITLE
DEV-8908 appstream auto Scale

### DIFF
--- a/run_terminate_appstream_fleet_autoscale.py
+++ b/run_terminate_appstream_fleet_autoscale.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
 
     env = env['appstream']['STACK'][0]
     stack_name = env['NAME']
-    fleet_name = f'fleet/{env["FLEET_NAME"]}'
+    fleet_path = f'fleet/{env["FLEET_NAME"]}'
     appstream_scaling_out_policy = env["APPSTREAM_SCALING_OUT_POLICY"]
     appstream_scaling_in_policy = env["APPSTREAM_SCALING_IN_POLICY"]
 
@@ -22,22 +22,16 @@ if __name__ == "__main__":
     #
     ################################################################################
 
-    cc = ['application-autoscaling', 'delete-scaling-policy']
-    cc += ['--policy-name', appstream_scaling_out_policy]
-    cc += ['--service-namespace', 'appstream']
-    cc += ['--resource-id', fleet_name]
-    cc += ['--scalable-dimension', 'appstream:fleet:DesiredCapacity']
+    cc = ['cloudwatch', 'delete-alarms']
+    cc += ['--alarm-names', appstream_scaling_out_policy]
     aws_cli.run(cc, ignore_error=True)
 
-    cc = ['application-autoscaling', 'delete-scaling-policy']
-    cc += ['--policy-name', appstream_scaling_in_policy]
-    cc += ['--service-namespace', 'appstream']
-    cc += ['--resource-id', fleet_name]
-    cc += ['--scalable-dimension', 'appstream:fleet:DesiredCapacity']
+    cc = ['cloudwatch', 'delete-alarms']
+    cc += ['--alarm-names', appstream_scaling_in_policy]
     aws_cli.run(cc, ignore_error=True)
 
     cc = ['application-autoscaling', 'deregister-scalable-target']
     cc += ['--service-namespace', 'appstream']
-    cc += ['--resource-id', fleet_name]
+    cc += ['--resource-id', fleet_path]
     cc += ['--scalable-dimension', 'appstream:fleet:DesiredCapacity']
     aws_cli.run(cc, ignore_error=True)

--- a/run_terminate_appstream_fleet_autoscale.py
+++ b/run_terminate_appstream_fleet_autoscale.py
@@ -13,7 +13,8 @@ if __name__ == "__main__":
     env = env['appstream']['STACK'][0]
     stack_name = env['NAME']
     fleet_name = f'fleet/{env["FLEET_NAME"]}'
-    appstream_policy_name = env["APPSTREAM_SCALING_POLICY"]
+    appstream_scaling_out_policy = env["APPSTREAM_SCALING_OUT_POLICY"]
+    appstream_scaling_in_policy = env["APPSTREAM_SCALING_IN_POLICY"]
 
     ################################################################################
     #
@@ -22,7 +23,14 @@ if __name__ == "__main__":
     ################################################################################
 
     cc = ['application-autoscaling', 'delete-scaling-policy']
-    cc += ['--policy-name', appstream_policy_name]
+    cc += ['--policy-name', appstream_scaling_out_policy]
+    cc += ['--service-namespace', 'appstream']
+    cc += ['--resource-id', fleet_name]
+    cc += ['--scalable-dimension', 'appstream:fleet:DesiredCapacity']
+    aws_cli.run(cc, ignore_error=True)
+
+    cc = ['application-autoscaling', 'delete-scaling-policy']
+    cc += ['--policy-name', appstream_scaling_in_policy]
     cc += ['--service-namespace', 'appstream']
     cc += ['--resource-id', fleet_name]
     cc += ['--scalable-dimension', 'appstream:fleet:DesiredCapacity']


### PR DESCRIPTION
### What is this PR for?
-https://docs.aws.amazon.com/appstream2/latest/developerguide/autoscaling.html
기존 5번의 autoscale 정책을 사용하던 방식에서 1번(용량기반 scale out) 과 3번(용량이반 scale in) 정책으로 변경

### How should this be tested?
- Appstream을 fleet을 생성 후 해당 autoscale 파일을 실행시켜 주세요.
