### PR TITLE
DEV-9329 describe_vpc_peering_connection 에러 발생시, false 반환하도록 설정

### DIFF
--- a/run_describe_cloudwatch.py
+++ b/run_describe_cloudwatch.py
@@ -38,7 +38,7 @@ def describe_cloudwatch_alarm():
     a_set = set()
     alarms_list = env['cloudwatch']['ALARMS']
     for al in alarms_list:
-        a_name = f"{al['NAME']}_{al['AWS_DEFAULT_REGION']}_{al['METRIC_NAME']}"
+        a_name = f"{al['NAME']}_{al['AWS_DEFAULT_REGION']}_{al.get('METRIC_NAME', '')}"
         a_set.add(f'"{a_name}"')
 
     cmd = ['cloudwatch', 'describe-alarms']

--- a/run_describe_vpc.py
+++ b/run_describe_vpc.py
@@ -135,7 +135,7 @@ def describe_vpc_peering_connection(vpc_id_1, vpc_id_2):
     cmd += [f'--filters={filter_1},{filter_2}']
     result = aws_cli.run(cmd, ignore_error=True)
 
-    if not result['VpcPeeringConnections']:
+    if not result or not result['VpcPeeringConnections']:
         return False
     else:
         return True


### PR DESCRIPTION
### What is this PR for?
- `ec2 describe-vpc-peering-connections` 명령어에서 에러 발생시 empty string 값이 와서 에러 처리를 해줌
- cloudwatch metric 에서 `METRIC_NAME` 값이 없는 녀석도 있어서, 없을 경어 empty string 기본 값을 설정

### How should this be tested?
- `run.py describe` 실행시 실패 없이 진행 되면 성공