### PR TITLE
DEV-9649 Add S3 CORS

### DIFF
--- a/run_create_s3_bucket.py
+++ b/run_create_s3_bucket.py
@@ -55,6 +55,23 @@ def run_create_s3_bucket(name, settings):
                 'file://aws_iam/aws-s3-website-configuration.json']
         aws_cli.run(cmd)
 
+        print_message('set cors')
+        cc = {
+            "CORSRules": [
+                {
+                    "AllowedOrigins": ["*"],
+                    "AllowedMethods": ["GET"],
+                    "MaxAgeSeconds": 3000,
+                    "AllowedHeaders": ["Authorization"]
+                }
+            ]
+        }
+
+        cmd = ['s3api', 'put-bucket-cors']
+        cmd += ['--bucket', bucket_name]
+        cmd += ['--cors-configuration', json.dumps(cc)]
+        aws_cli.run(cmd)
+
     ################################################################################
     if expire_days > 0:
         print_message('set life cycle rule')

--- a/run_terminate_s3_bucket.py
+++ b/run_terminate_s3_bucket.py
@@ -32,6 +32,12 @@ def run_terminate_s3_bucket(name, settings):
     aws_cli.run(cmd, ignore_error=True)
 
     ################################################################################
+    print_message('delete cors')
+
+    cmd = ['s3api', 'delete-bucket-cors', '--bucket', bucket_name]
+    aws_cli.run(cmd, ignore_error=True)
+
+    ################################################################################
     print_message('restore public access block')
 
     pp = {


### PR DESCRIPTION
### What is this PR for?
- 외부에 공개된 result 버켓에 CORS 설정이 없어 DV 환경에서 Deep QA 실행 결과를 못봄 (브라우저에서 CORS 문제로 막힘)
    - s3 주소를 사용중인 dv 환경의 경우 `웹호스팅`을 켜는 버킷에 대해 CORS 설정을 추가 필요
    - config.json에 `WEB_HOSTING`을 활용

### How should this be tested?
- ./run_create_s3.py [email id]-dv-hbsmith-result 실행 
    - `./run_create_s3.py jaypae95-dv-hbsmith-result
- 사진과 같이 CORS 설정이 다 되어있는 지 확인
![image](https://user-images.githubusercontent.com/32082483/87285877-0a98a000-c533-11ea-9303-dcb926f35e83.png)
- ./run_terminate_s3.py [email id]-dv-hbsmith-result 실행 
    - `./run_terminate_s3.py jaypae95-dv-hbsmith-result
- 새로고침 하여 사진과 같이 CORS 설정이 잘 지워졌는 지 확인
![image](https://user-images.githubusercontent.com/32082483/87286013-3ddb2f00-c533-11ea-901f-d8888b5a0f19.png)
