### PR TITLE
DEV-10154 run.py create 빌드 시간을 줄기이 위해 동작 순서 변경

### DIFF
--- a/run.py
+++ b/run.py
@@ -117,8 +117,8 @@ if __name__ == "__main__":
     if command == 'run_create':
         __import__('run_create_iam')
         __import__('run_create_vpc')
-        __import__('run_create_ec2_client_vpn')
         __import__('run_create_rds')
+        __import__('run_create_ec2_client_vpn')
         __import__('run_create_sqs')
         __import__('run_reset_database')
         __import__('run_create_eb')


### PR DESCRIPTION
### What is this PR for?
- rds 세팅 하면 바로 reset datebase 할 수 없어 긴시간을 wait 해야 하는데 `run_create_ec2_client_vpn` 를 `run_create_rds` 뒤에 배치 해서 대기 시간이 없음
https://github.com/HardBoiledSmith/johanna/blob/a96dc00127be9312cb83204e68e487bbfc344d6a/run_codebuild_wait_done.py#L96

### How should this be tested?
- `run.py create` 를 실행 해서 문제 없으면 성공

### Screenshots (if appropriate)
- codebuild project 생성후 wait 가 없이 바로 실행 됨
<img width="1627" alt="스크린샷 2020-10-21 오전 12 26 17" src="https://user-images.githubusercontent.com/11402853/96609641-b3764880-1335-11eb-9487-2d1dfcce4e69.png">

