### PR TITLE
DEV-10553 comment ignore base64

### DIFF
--- a/run_create_vpc.py
+++ b/run_create_vpc.py
@@ -48,7 +48,8 @@ def main(settings):
     cmd = ['ec2', 'import-key-pair']
     cmd += ['--key-name', env['common']['AWS_KEY_PAIR_NAME']]
     cmd += ['--public-key-material', env['common']['AWS_KEY_PAIR_MATERIAL']]
-    cmd += ['--cli-binary-format', 'raw-in-base64-out']
+    # TODO : aws cli2 need option of ignore base64
+    # cmd += ['--cli-binary-format', 'raw-in-base64-out']
     aws_cli.run(cmd)
 
     ################################################################################


### PR DESCRIPTION
### What is this PR for?
- aws cli1 에서 동작을 위해 aws cli2 를 위해 추가한 base64 무시 하는 설정을 주석 처리함
