### PR TITLE
DEV-10652 cloudwatch chart 에서 여러 metric 이 한 chart 에 보여지도록 수정

### DIFF
--- a/run_create_cloudwatch_dashboard.py
+++ b/run_create_cloudwatch_dashboard.py
@@ -128,40 +128,34 @@ def run_create_cw_dashboard_elasticbeanstalk(name, settings):
             elif dimension == 'TargetGroup':
                 dimension_type = 'tg'
 
-        template = json.dumps(pm[0])
-        new_metrics_list = list()
+        template = json.dumps(pm)
         if dimension_type == 'asg':
             for ii in env_asg_list:
                 new_metric = template.replace('AUTO_SCALING_GROUP_NAME', ii['Name'])
                 new_metric = new_metric.replace('ENVIRONMENT_NAME', ii['EnvironmentName'])
                 new_metric = json.loads(new_metric)
-                new_metrics_list.append(new_metric)
         elif dimension_type == 'instance':
             for ii in env_instances_list:
                 new_metric = template.replace('INSTANCE_ID', ii['Id'])
                 new_metric = new_metric.replace('ENVIRONMENT_NAME', ii['EnvironmentName'])
                 new_metric = json.loads(new_metric)
-                new_metrics_list.append(new_metric)
         elif dimension_type == 'elb':
             for ii in env_elb_list:
                 new_metric = template.replace('LOAD_BALANCER_NAME', ii['Name'])
                 new_metric = new_metric.replace('ENVIRONMENT_NAME', ii['EnvironmentName'])
                 new_metric = json.loads(new_metric)
-                new_metrics_list.append(new_metric)
         elif dimension_type == 'tg':
             for ii in env_tg_list:
                 new_metric = template.replace('TARGET_GROUP', ii['Name'])
                 new_metric = new_metric.replace('LOAD_BALANCER', ii['LoadBalancer'])
                 new_metric = new_metric.replace('ENVIRONMENT_NAME', ii['EnvironmentName'])
                 new_metric = json.loads(new_metric)
-                new_metrics_list.append(new_metric)
         else:
             for ii in env_list:
                 new_metric = template.replace('ENVIRONMENT_NAME', ii['EnvironmentName'])
                 new_metric = json.loads(new_metric)
-                new_metrics_list.append(new_metric)
 
-        dw['properties']['metrics'] = new_metrics_list
+        dw['properties']['metrics'] = new_metric
 
     dashboard_body = json.dumps(dashboard_body)
 


### PR DESCRIPTION
### What is this PR for?
- gendo autoscale 모니터링을 위해 , HealthyHostCount, UnHealthyHostCount, ApproximateNumberOfMessagesVisible 지표를 동시해 표현 하면 파악이 용의 해서 여러 metric 이 한 chart 에 보여질 필요가 있음
- 기존에 metric 1번째만 사용 해서 여러 metrics 기진 cloudwatch 설정이 있나 확인 해 보았으나 모두 단일한 metric 만 있어 로직 변동으로 기존 기능에 영향을 없을 것으로 판단됨

### How should this be tested?
- beanstalk 를  세팅 하고 `run_create_cloudwatch_dashboard.py <beanstalk name>` 으로 dashboard 만들고 정상적으로 나오는지 확인



