### PR TITLE
DEV-10781 gendo 를 띄울 때 Enhanced Monitoring 을 활성화 함

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -357,7 +357,7 @@ def run_create_eb_windows(name, settings):
     oo = dict()
     oo['Namespace'] = 'aws:elasticbeanstalk:healthreporting:system'
     oo['OptionName'] = 'SystemType'
-    oo['Value'] = 'basic'
+    oo['Value'] = 'enhanced'
     option_settings.append(oo)
 
     oo = dict()


### PR DESCRIPTION
### What is this PR for?
- gendo 를 띄울 때 Enhanced Monitoring 을 활성화 함
- 각 인스턴스의 상태를 확인 할 수 있음

### How should this be tested?
- johanna 로 iam, vpc, eb(gendo) 를 띄운뒤 Enhanced Monitoring 을 활성화 됐는지 확인
- gendo Health 가 Ok(Green 이 아닌) 보이는지 확인

### Screenshots (if appropriate)
<img width="1290" alt="스크린샷 2020-12-26 오후 3 06 26" src="https://user-images.githubusercontent.com/11402853/103146438-ac801200-478c-11eb-9580-2252cb8c3ae3.png">
<img width="1286" alt="스크린샷 2020-12-26 오후 3 06 45" src="https://user-images.githubusercontent.com/11402853/103146436-aa1db800-478c-11eb-93b6-41b53794652b.png">

