### PR TITLE
DEV-10869 Cloudwatch Gendo Dashboard SQS 지표 수정

### DIFF
--- a/run_create_cloudwatch_alarm.py
+++ b/run_create_cloudwatch_alarm.py
@@ -158,6 +158,8 @@ def run_create_cloudwatch_alarm_elasticbeanstalk(name, settings):
     cmd += ['--period', settings['PERIOD']]
     cmd += ['--statistic', settings['STATISTIC']]
     cmd += ['--threshold', settings['THRESHOLD']]
+    if 'INSUFFICIENT_DATA_ACTIONS' in settings:
+        cmd += ['--treat-missing-data', settings['INSUFFICIENT_DATA_ACTIONS']]
     aws_cli.run(cmd)
 
 

--- a/run_create_cloudwatch_alarm.py
+++ b/run_create_cloudwatch_alarm.py
@@ -158,8 +158,6 @@ def run_create_cloudwatch_alarm_elasticbeanstalk(name, settings):
     cmd += ['--period', settings['PERIOD']]
     cmd += ['--statistic', settings['STATISTIC']]
     cmd += ['--threshold', settings['THRESHOLD']]
-    if 'INSUFFICIENT_DATA_ACTIONS' in settings:
-        cmd += ['--treat-missing-data', settings['INSUFFICIENT_DATA_ACTIONS']]
     aws_cli.run(cmd)
 
 

--- a/run_create_cloudwatch_dashboard.py
+++ b/run_create_cloudwatch_dashboard.py
@@ -317,7 +317,7 @@ def run_create_cw_dashboard_alarm(name, settings):
 ################################################################################
 print_session('create cloudwatch dashboard')
 
-# reset_template_dir()
+reset_template_dir()
 
 cw = env.get('cloudwatch', dict())
 target_cw_dashboard_name = None

--- a/run_create_cloudwatch_dashboard.py
+++ b/run_create_cloudwatch_dashboard.py
@@ -250,7 +250,6 @@ def run_create_cw_dashboard_sqs_lambda_sms(name, settings):
         for pp in pm:
             template = json.dumps(pp)
             template = template.replace('PHASE-', '%s-' % phase)
-            print(template)
             pm[current_index] = json.loads(template)
             current_index += 1
 

--- a/run_create_cloudwatch_dashboard.py
+++ b/run_create_cloudwatch_dashboard.py
@@ -159,7 +159,9 @@ def run_create_cw_dashboard_elasticbeanstalk(name, settings):
 
         dw['properties']['metrics'] = new_metric
 
+    phase = env['common']['PHASE']
     dashboard_body = json.dumps(dashboard_body)
+    dashboard_body = dashboard_body.replace('PHASE-', '%s-' % phase)
 
     cmd = ['cloudwatch', 'put-dashboard']
     cmd += ['--dashboard-name', dashboard_name]
@@ -248,6 +250,7 @@ def run_create_cw_dashboard_sqs_lambda_sms(name, settings):
         for pp in pm:
             template = json.dumps(pp)
             template = template.replace('PHASE-', '%s-' % phase)
+            print(template)
             pm[current_index] = json.loads(template)
             current_index += 1
 
@@ -314,7 +317,7 @@ def run_create_cw_dashboard_alarm(name, settings):
 ################################################################################
 print_session('create cloudwatch dashboard')
 
-reset_template_dir()
+# reset_template_dir()
 
 cw = env.get('cloudwatch', dict())
 target_cw_dashboard_name = None


### PR DESCRIPTION
### What is this PR for?
- gendo 대시보드의 sqs 지표 대상이 잘못 표기가 되어 있어 수정 해야함.

### How should this be tested?
- vagrant johanna를 띄운 후 run_common파일에서 reset_template_dir 함수의 git clone 브랜치를 해당 브랜치로 받도록 변경해주세요.
- ./run_create_cloudwatch_dashboard.py gendo 커멘드를 통해 환경을 띄워주세요.

config.json으로 세팅한 aws 계정으로 접속해 cloudwatch 대시보드탭 -> __gendo_ap-northeast-2  을 들어가 아래 스크린샷의 탭을 확인해주세요.

### Screenshots (if appropriate)
본 이미지는 dv환경 풀 인프라를 띄워서 체크 된 데이터들 입니다.
![image](https://user-images.githubusercontent.com/42234701/104001224-afdeb900-51e2-11eb-9d00-1e5779f1711e.png)

연관 PR
https://github.com/HardBoiledSmith/magi/pull/707