### PR TITLE
DEV-8941 gendo 난죽택 관련 metric 수정 - 오동작 또는 미동작시 알람처리

### DIFF
--- a/run_create_cloudwatch_alarm.py
+++ b/run_create_cloudwatch_alarm.py
@@ -158,6 +158,8 @@ def run_create_cloudwatch_alarm_elasticbeanstalk(name, settings):
     cmd += ['--period', settings['PERIOD']]
     cmd += ['--statistic', settings['STATISTIC']]
     cmd += ['--threshold', settings['THRESHOLD']]
+    if 'INSUFFICIENT_DATA_ACTIONS' in settings:
+        cmd += ['--treat-missing-data', settings['INSUFFICIENT_DATA_ACTIONS']]
     aws_cli.run(cmd)
 
 


### PR DESCRIPTION
### What is this PR for?
- GendoActiveStatus에 alarm 추가
    - Metric = SuccessCount 가 1시간동안 0이면 알람 발생 
- GendoActiveStatus를 gendo_ap-northeast-2 대시보드에 추가

### How should this be tested?
- AWS gendo를 테스트 하기 위한 환경을 구성해 주세요. ( iam, vpc, rds, client_vpn, sachiel, sqs, lambda, gendo, cloudwatchbash board , cloudwatch alarm )
johanna를 통해 환경을 구성할 때 cloudwatch 및 gendo를 생성할 때 DEV-8941 브랜치로 올라가게끔 작업을 해야합니다.

- 구성이 완료 되면 구성한 app console로 접속하여 테스트를 실행시켜 Gendo가 실행 후 결과를 기록하도록 합니다.

- cloudwatch Dashbard에 gendo_ap-northeast-2 탭에 들어가 GendoActiveStatus의 지표(IdleCount, BucyCount, SuccessCount)가 기록되어야 합니다.

- 지표에 따른 알람이 잘 동작해야 합니다.



### Screenshots (if appropriate)
**1시간동안 6번 체크하여 SuccessCount 지표의 Sum이 1이상일 아닐 경우 정상**
![스크린샷 2021-01-08 오후 10 50 25](https://user-images.githubusercontent.com/42234701/104039832-39f64400-521a-11eb-9746-9fa8f51af209.png)


**1시간동안 6번 체크하여 SuccessCount 지표의 Sum이 1미만일 아닐 경우 알람**
![스크린샷 2021-01-09 오전 1 01 27](https://user-images.githubusercontent.com/42234701/104039787-26e37400-521a-11eb-8a7c-5695f9029982.png)

gendo_ap-northeast-2대시보드에 GendoActiveStatus 지표가 추가된 Dashboard 
![image](https://user-images.githubusercontent.com/42234701/104039977-6d38d300-521a-11eb-9433-f064661dfd0f.png)


관련 PR
https://github.com/HardBoiledSmith/gendo/pull/490
https://github.com/HardBoiledSmith/magi/pull/708