### PR TITLE
DEV-11090 SSM 을 위한 IAM policy 추가.

### DIFF
--- a/run_create_iam.py
+++ b/run_create_iam.py
@@ -52,6 +52,11 @@ def create_iam():
     cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier']
     aws_cli.run(cmd)
 
+    cmd = ['iam', 'attach-role-policy']
+    cmd += ['--role-name', 'aws-elasticbeanstalk-ec2-role']
+    cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore']
+    aws_cli.run(cmd)
+
     cmd = ['iam', 'put-role-policy']
     cmd += ['--role-name', 'aws-elasticbeanstalk-ec2-role']
     cmd += ['--policy-name', 'aws-elasticbeanstalk-ec2-policy']

--- a/run_terminate_iam.py
+++ b/run_terminate_iam.py
@@ -59,6 +59,11 @@ def terminate_iam():
     cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier']
     aws_cli.run(cmd, ignore_error=True)
 
+    cmd = ['iam', 'detach-role-policy']
+    cmd += ['--role-name', 'aws-elasticbeanstalk-ec2-role']
+    cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore']
+    aws_cli.run(cmd)
+
     cmd = ['iam', 'remove-role-from-instance-profile']
     cmd += ['--instance-profile-name', 'aws-elasticbeanstalk-ec2-role']
     cmd += ['--role-name', 'aws-elasticbeanstalk-ec2-role']


### PR DESCRIPTION
### What is this PR for?
- EC2 콘솔 > 연결 > Session Manager : 웹 UI 로 콘솔 접근이 가능하도록 IAM Policy 추가.
- 관련 문서 : https://hbsmith.atlassian.net/wiki/spaces/GEN/pages/1575453109/SSM+For+Elastic+Beanstalk
    - AWS System Manager > Session Manager > 기본 설정 > “Linux 인스턴스에 대해 Run As 지원 활성화” 를 통해 ssm-user 를 ec2-user 등으로 변경할 수 있습니다.
    - 키페어 제거 작업은 추후 진행 여부를 결정하기로 스크럼 회의 때 결정되었습니다.

### How should this be tested?
- johanna 가 정상적으로 프로비저닝되어야 합니다.
- iam > vpc > rds 순으로 프로비저닝 후 eb 를 프로비저닝하였을 때 ec2 콘솔에서 스크린샷과 같이 기능 접근이 가능해야 합니다.

### Screenshots (if appropriate)
https://user-images.githubusercontent.com/29401441/105632829-9c954400-5e98-11eb-88f3-09f0b49229ca.mov


