### PR TITLE
DEV-11199 (in-progress) AZ b, d 확장된 HBsmith  VPC 인프라 Johhan code로 생성 (패치 이후 적용)

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -50,11 +50,17 @@ class AWSCli:
     cidr_subnet['rds'] = dict()
     cidr_subnet['rds']['private_1'] = env['common']['AWS_SUBNET_RDS_PRIVATE_1']
     cidr_subnet['rds']['private_2'] = env['common']['AWS_SUBNET_RDS_PRIVATE_2']
+    cidr_subnet['rds']['private_3'] = env['common']['AWS_SUBNET_RDS_PRIVATE_3']
+    cidr_subnet['rds']['private_4'] = env['common']['AWS_SUBNET_RDS_PRIVATE_4']
     cidr_subnet['eb'] = dict()
     cidr_subnet['eb']['private_1'] = env['common']['AWS_SUBNET_EB_PRIVATE_1']
     cidr_subnet['eb']['private_2'] = env['common']['AWS_SUBNET_EB_PRIVATE_2']
+    cidr_subnet['eb']['private_3'] = env['common']['AWS_SUBNET_EB_PRIVATE_3']
+    cidr_subnet['eb']['private_4'] = env['common']['AWS_SUBNET_EB_PRIVATE_4']
     cidr_subnet['eb']['public_1'] = env['common']['AWS_SUBNET_EB_PUBLIC_1']
     cidr_subnet['eb']['public_2'] = env['common']['AWS_SUBNET_EB_PUBLIC_2']
+    cidr_subnet['eb']['public_3'] = env['common']['AWS_SUBNET_EB_PUBLIC_3']
+    cidr_subnet['eb']['public_4'] = env['common']['AWS_SUBNET_EB_PUBLIC_4']
 
     def __init__(self, aws_default_region=None, aws_access_key=None, aws_secret_access_key=None):
         if not env['aws'].get('AWS_ACCESS_KEY_ID') or \


### PR DESCRIPTION
### What is this PR for?
- create_vpc 실행 시 AZ (a,b,c,d)로 구성되도록 Johhana 코드 수정.

**merge 전 주의 사항**
https://github.com/HardBoiledSmith/magi/pull/720
https://github.com/HardBoiledSmith/johanna/pull/433
위 두 PR이 선행되어야 하며, 해당 PR은 나중 OP패치가 적용 된 이후에 적용이 되어야 합니다. OP 패치의 계획상 VPC의 경우 수동으로 직접 늘린 후 나머지는 코드로 띄우도록 작성 하였습니다.

### How should this be tested?
- ./run.py iam, 
- ./run.py create_vpc를 진행 해 주세요.
- subnet, route table, rds groups 에 abcd가 잘 적용이 되었는지 확인해주세요.

### Screenshots (if appropriate)

https://hbsmith.atlassian.net/wiki/spaces/GEN/pages/1569751074/ap-northeast-2b+ap-northeast-2d+OP
의 문서에 생성 된 환경에 대한 값들이 스크린샷으로 있습니다. eb를 제외한 VPC 세팅 부분을 참고하면 됩니다.
