### PR TITLE
DEV-11097 HBsmith AZ 4개로 확장 및 Desired Capacity 조절.

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -50,11 +50,17 @@ class AWSCli:
     cidr_subnet['rds'] = dict()
     cidr_subnet['rds']['private_1'] = env['common']['AWS_SUBNET_RDS_PRIVATE_1']
     cidr_subnet['rds']['private_2'] = env['common']['AWS_SUBNET_RDS_PRIVATE_2']
+    cidr_subnet['rds']['private_3'] = env['common']['AWS_SUBNET_RDS_PRIVATE_3']
+    cidr_subnet['rds']['private_4'] = env['common']['AWS_SUBNET_RDS_PRIVATE_4']
     cidr_subnet['eb'] = dict()
     cidr_subnet['eb']['private_1'] = env['common']['AWS_SUBNET_EB_PRIVATE_1']
     cidr_subnet['eb']['private_2'] = env['common']['AWS_SUBNET_EB_PRIVATE_2']
+    cidr_subnet['eb']['private_3'] = env['common']['AWS_SUBNET_EB_PRIVATE_3']
+    cidr_subnet['eb']['private_4'] = env['common']['AWS_SUBNET_EB_PRIVATE_4']
     cidr_subnet['eb']['public_1'] = env['common']['AWS_SUBNET_EB_PUBLIC_1']
     cidr_subnet['eb']['public_2'] = env['common']['AWS_SUBNET_EB_PUBLIC_2']
+    cidr_subnet['eb']['public_3'] = env['common']['AWS_SUBNET_EB_PUBLIC_3']
+    cidr_subnet['eb']['public_4'] = env['common']['AWS_SUBNET_EB_PUBLIC_4']
 
     def __init__(self, aws_default_region=None, aws_access_key=None, aws_secret_access_key=None):
         if not env['aws'].get('AWS_ACCESS_KEY_ID') or \

--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -65,8 +65,12 @@ def run_create_eb_django(name, settings):
 
     elb_subnet_id_1 = None
     elb_subnet_id_2 = None
+    elb_subnet_id_3 = None
+    elb_subnet_id_4 = None
     ec2_subnet_id_1 = None
     ec2_subnet_id_2 = None
+    ec2_subnet_id_3 = None
+    ec2_subnet_id_4 = None
     cmd = ['ec2', 'describe-subnets']
     result = aws_cli.run(cmd)
     for r in result['Subnets']:
@@ -77,15 +81,27 @@ def run_create_eb_django(name, settings):
                 elb_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['public_2']:
                 elb_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['public_3']:
+                elb_subnet_id_1 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['public_4']:
+                elb_subnet_id_2 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
+                ec2_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
+                ec2_subnet_id_1 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
                 ec2_subnet_id_2 = r['SubnetId']
         elif 'private' == subnet_type:
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 elb_subnet_id_1 = ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
                 elb_subnet_id_2 = ec2_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
+                elb_subnet_id_3 = ec2_subnet_id_3 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
+                elb_subnet_id_4 = ec2_subnet_id_4 = r['SubnetId']
         else:
             print('ERROR!!! Unknown subnet type:', subnet_type)
             raise Exception()
@@ -313,13 +329,13 @@ def run_create_eb_django(name, settings):
     oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'ELBSubnets'
-    oo['Value'] = ','.join([elb_subnet_id_1, elb_subnet_id_2])
+    oo['Value'] = ','.join([elb_subnet_id_1, elb_subnet_id_2, elb_subnet_id_3, elb_subnet_id_4])
     option_settings.append(oo)
 
     oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'Subnets'
-    oo['Value'] = ','.join([ec2_subnet_id_1, ec2_subnet_id_2])
+    oo['Value'] = ','.join([ec2_subnet_id_1, ec2_subnet_id_2, ec2_subnet_id_3, ec2_subnet_id_4])
     option_settings.append(oo)
 
     oo = dict()

--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -82,17 +82,17 @@ def run_create_eb_django(name, settings):
             if r['CidrBlock'] == cidr_subnet['eb']['public_2']:
                 elb_subnet_id_2 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['public_3']:
-                elb_subnet_id_1 = r['SubnetId']
+                elb_subnet_id_3 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['public_4']:
-                elb_subnet_id_2 = r['SubnetId']
+                elb_subnet_id_4 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
                 ec2_subnet_id_2 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
-                ec2_subnet_id_1 = r['SubnetId']
+                ec2_subnet_id_3 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
-                ec2_subnet_id_2 = r['SubnetId']
+                ec2_subnet_id_4 = r['SubnetId']
         elif 'private' == subnet_type:
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 elb_subnet_id_1 = ec2_subnet_id_1 = r['SubnetId']
@@ -424,7 +424,7 @@ def run_create_eb_django(name, settings):
     cmd += ['--cname-prefix', cname]
     cmd += ['--environment-name', eb_environment_name]
     cmd += ['--option-settings', option_settings]
-    cmd += ['--solution-stack-name', '64bit Amazon Linux 2018.03 v2.9.17 running Python 3.6']
+    cmd += ['--solution-stack-name', '64bit Amazon Linux 2018.03 v2.9.18 running Python 3.6']
     cmd += ['--tags', tag0, tag1]
     cmd += ['--version-label', eb_environment_name]
     aws_cli.run(cmd, cwd=template_path)

--- a/run_create_eb_django_al2.py
+++ b/run_create_eb_django_al2.py
@@ -65,8 +65,12 @@ def run_create_eb_django_al2(name, settings):
 
     elb_subnet_id_1 = None
     elb_subnet_id_2 = None
+    elb_subnet_id_3 = None
+    elb_subnet_id_4 = None
     ec2_subnet_id_1 = None
     ec2_subnet_id_2 = None
+    ec2_subnet_id_3 = None
+    ec2_subnet_id_4 = None
     cmd = ['ec2', 'describe-subnets']
     result = aws_cli.run(cmd)
     for r in result['Subnets']:
@@ -77,15 +81,27 @@ def run_create_eb_django_al2(name, settings):
                 elb_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['public_2']:
                 elb_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['public_3']:
+                elb_subnet_id_1 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['public_4']:
+                elb_subnet_id_2 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
+                ec2_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
+                ec2_subnet_id_1 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
                 ec2_subnet_id_2 = r['SubnetId']
         elif 'private' == subnet_type:
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 elb_subnet_id_1 = ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
                 elb_subnet_id_2 = ec2_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
+                elb_subnet_id_3 = ec2_subnet_id_3 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
+                elb_subnet_id_4 = ec2_subnet_id_4 = r['SubnetId']
         else:
             print('ERROR!!! Unknown subnet type:', subnet_type)
             raise Exception()
@@ -316,13 +332,13 @@ def run_create_eb_django_al2(name, settings):
     oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'ELBSubnets'
-    oo['Value'] = ','.join([elb_subnet_id_1, elb_subnet_id_2])
+    oo['Value'] = ','.join([elb_subnet_id_1, elb_subnet_id_2, elb_subnet_id_3, elb_subnet_id_4])
     option_settings.append(oo)
 
     oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'Subnets'
-    oo['Value'] = ','.join([ec2_subnet_id_1, ec2_subnet_id_2])
+    oo['Value'] = ','.join([ec2_subnet_id_1, ec2_subnet_id_2, ec2_subnet_id_3, ec2_subnet_id_4])
     option_settings.append(oo)
 
     oo = dict()

--- a/run_create_eb_django_al2.py
+++ b/run_create_eb_django_al2.py
@@ -427,7 +427,7 @@ def run_create_eb_django_al2(name, settings):
     cmd += ['--cname-prefix', cname]
     cmd += ['--environment-name', eb_environment_name]
     cmd += ['--option-settings', option_settings]
-    cmd += ['--solution-stack-name', '64bit Amazon Linux 2 v3.1.4 running Python 3.7']
+    cmd += ['--solution-stack-name', '64bit Amazon Linux 2 v3.1.5 running Python 3.7']
     cmd += ['--tags', tag0, tag1]
     cmd += ['--version-label', eb_environment_name]
     aws_cli.run(cmd, cwd=template_path)

--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -479,12 +479,24 @@ def run_create_eb_windows(name, settings):
 
         eb_old_autoscaling_group_desired_capacity = str(rr['AutoScalingGroups'][0]['DesiredCapacity'])
 
-        print_message('update desired capacity of eb new and old auto scaling-groups')
+        print_message('update desired capacity of eb new auto scaling-groups')
 
         cmd = ['autoscaling', 'update-auto-scaling-group']
         cmd += ['--auto-scaling-group-name', eb_new_autoscaling_group_name]
         cmd += ['--desired-capacity', eb_old_autoscaling_group_desired_capacity]
         aws_cli.run(cmd)
+
+        elapsed_time = 0
+        while True:
+            print(f'20 minutes while waiting for new gendo generation... (elapsed time: {elapsed_time} seconds)')
+
+            if elapsed_time > 60 * 20:
+                break
+
+            time.sleep(30)
+            elapsed_time += 30
+
+        print_message('update desired capacity of eb old auto scaling-groups')
 
         cmd = ['autoscaling', 'update-auto-scaling-group']
         cmd += ['--auto-scaling-group-name', eb_old_autoscaling_group_name]
@@ -501,12 +513,10 @@ def run_create_eb_windows(name, settings):
             if eb_environment_id_old in alarm['AlarmName']:
                 ll.append(alarm['AlarmName'])
 
-        if not ll:
-            return
+        if ll:
+            print_message('delete eb old environment cloudwatch alarms')
 
-        print_message('delete eb old environment cloudwatch alarms')
-
-        for alarm in ll:
-            cmd = ['cloudwatch', 'delete-alarms']
-            cmd += ['--alarm-names', alarm]
-            aws_cli.run(cmd)
+            for alarm in ll:
+                cmd = ['cloudwatch', 'delete-alarms']
+                cmd += ['--alarm-names', alarm]
+                aws_cli.run(cmd)

--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -490,3 +490,23 @@ def run_create_eb_windows(name, settings):
         cmd += ['--auto-scaling-group-name', eb_old_autoscaling_group_name]
         cmd += ['--desired-capacity', aws_asg_min_value]
         aws_cli.run(cmd)
+
+        print_message('describe cloudwatch alrams')
+
+        ll = list()
+        cmd = ['cloudwatch', 'describe-alarms']
+        rr = aws_cli.run(cmd)
+
+        for alarm in rr['MetricAlarms']:
+            if eb_environment_id_old in alarm['AlarmName']:
+                ll.append(alarm['AlarmName'])
+
+        if not ll:
+            return
+
+        print_message('delete eb old environment cloudwatch alarms')
+
+        for alarm in ll:
+            cmd = ['cloudwatch', 'delete-alarms']
+            cmd += ['--alarm-names', alarm]
+            aws_cli.run(cmd)

--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -68,8 +68,12 @@ def run_create_eb_windows(name, settings):
 
     elb_subnet_id_1 = None
     elb_subnet_id_2 = None
+    elb_subnet_id_3 = None
+    elb_subnet_id_4 = None
     ec2_subnet_id_1 = None
     ec2_subnet_id_2 = None
+    ec2_subnet_id_3 = None
+    ec2_subnet_id_4 = None
     cmd = ['ec2', 'describe-subnets']
     result = aws_cli.run(cmd)
     for r in result['Subnets']:
@@ -80,15 +84,27 @@ def run_create_eb_windows(name, settings):
                 elb_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['public_2']:
                 elb_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['public_3']:
+                elb_subnet_id_3 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['public_4']:
+                elb_subnet_id_4 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
                 ec2_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
+                ec2_subnet_id_3 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
+                ec2_subnet_id_4 = r['SubnetId']
         elif 'private' == subnet_type:
             if r['CidrBlock'] == cidr_subnet['eb']['private_1']:
                 elb_subnet_id_1 = ec2_subnet_id_1 = r['SubnetId']
             if r['CidrBlock'] == cidr_subnet['eb']['private_2']:
                 elb_subnet_id_2 = ec2_subnet_id_2 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_3']:
+                elb_subnet_id_3 = ec2_subnet_id_3 = r['SubnetId']
+            if r['CidrBlock'] == cidr_subnet['eb']['private_4']:
+                elb_subnet_id_4 = ec2_subnet_id_4 = r['SubnetId']
         else:
             print('ERROR!!! Unknown subnet type:', subnet_type)
             raise Exception()
@@ -321,13 +337,13 @@ def run_create_eb_windows(name, settings):
     oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'ELBSubnets'
-    oo['Value'] = ','.join([elb_subnet_id_1, elb_subnet_id_2])
+    oo['Value'] = ','.join([elb_subnet_id_1, elb_subnet_id_2, elb_subnet_id_3, elb_subnet_id_4])
     option_settings.append(oo)
 
     oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'Subnets'
-    oo['Value'] = ','.join([ec2_subnet_id_1, ec2_subnet_id_2])
+    oo['Value'] = ','.join([ec2_subnet_id_1, ec2_subnet_id_2, ec2_subnet_id_3, ec2_subnet_id_4])
     option_settings.append(oo)
 
     oo = dict()


### PR DESCRIPTION
### What is this PR for?
- AWS VPC AZ 2 -> 4개로 확장.
- 확장 된 인프라에 맞게 eb(nerv, sachiel, gendo)가 생성 되도록 설정 변경.
- gendo의 경우 old_environment가 교체될 때 old env의 cloud watch alarm 제거 되도록 변경.
- https://github.com/HardBoiledSmith/magi/pull/720 의 config 값이 세팅되어 있어야 합니다.
- daily_cd를 위해 20분간 슬립을 거는 방식을 사용하도록 하겠습니다.

### How should this be tested?
- ./run.py iam, vpc를 실행해 주세요.
- AWS Console로 접속하여 vpc 세팅들을 체크해 주세요. Subnet, routeTable, DB subnet group들이 설정이 되어 있어야 합니다.
관련 문서는 https://hbsmith.atlassian.net/wiki/spaces/GEN/pages/1569751074/ap-northeast-2b+ap-northeast-2d+OP 에 있습니다.
- VPC 생성이 되었다면 ./run.py create_rds, ./run_create_ec2_client_vpn.py 후 DB를 세팅해주세요.
- rds 세팅이 끝나면 EB를 생성해 주세요. 
- 이 외 추가적으로 테스트해보기 위해서는 나머지 인프라 자원을 띄워주세요.
- 생성한 인프라들을 보면서 에러가 있는지 체크해주세요.
- vpc eb에 생성 된 자원들은 rds로 접속이 가능해야 합니다.
- Gendo의 경우 오래된 자원 교체되는 과정을 보기 위해서 ./run_create_eb.py gendo 를 해주어야 합니다.

### Screenshots (if appropriate)
기본적 세팅에 관련된 사진은 위 글에 적어둔 문서를 참고하면 보실 수 있습니다.

자원 생성 후 old 버전 있을 시 old eb env desired capacity new와 교체 및 min으로 줄이기 및 old eb env cloudwatch alamr 제거
![image](https://user-images.githubusercontent.com/42234701/110274906-45e06580-8013-11eb-8379-fe4d4130db99.png)


