### PR TITLE
DEV-11282 nerv의 eb-ec2 에서 sqs 접근을 위한 policy 추가

### DIFF
--- a/aws_iam/aws-elasticbeanstalk-ec2-policy.json
+++ b/aws_iam/aws-elasticbeanstalk-ec2-policy.json
@@ -25,6 +25,15 @@
         "ec2:DescribeInstanceCreditSpecifications"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "SQS",
+      "Effect": "Allow",
+      "Action": [
+        "sqs:GetQueueUrl",
+        "sqs:SendMessage"
+      ],
+      "Resource": "arn:aws:sqs:*:*:*"
     }
   ]
 }


### PR DESCRIPTION
### What is this PR for?
- elasticbeanstalk 의 django 코드에서 aws credentials 를 삭제하는 것에 대응하여 ec2 인스턴스에서 SQS로 접근할 수 있도록 권한을 추가하였습니다.

### How should this be tested?
- 관련 인프라를 본 브랜치로 프로비저닝하여 성공하여야 합니다.
- 일부러 nerv에 에러를 발생하여 sqs를 통하여 이메일을 전송받을 수 있어야 합니다.

### Screenshots (if appropriate)
<img width="3120" alt="aws-error" src="https://user-images.githubusercontent.com/29401441/110345886-5d9b0680-8072-11eb-916b-512d4bf39837.png">

