### PR TITLE
DEV-11414: change AWSElasticBeanstalkService to newer policy

### DIFF
--- a/run_create_iam.py
+++ b/run_create_iam.py
@@ -78,7 +78,7 @@ def create_iam():
 
     cmd = ['iam', 'attach-role-policy']
     cmd += ['--role-name', 'aws-elasticbeanstalk-service-role']
-    cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService']
+    cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy']
     aws_cli.run(cmd)
 
 

--- a/run_terminate_iam.py
+++ b/run_terminate_iam.py
@@ -24,7 +24,7 @@ def terminate_iam():
 
     cmd = ['iam', 'detach-role-policy']
     cmd += ['--role-name', 'aws-elasticbeanstalk-service-role']
-    cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService']
+    cmd += ['--policy-arn', 'arn:aws:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy']
     aws_cli.run(cmd, ignore_error=True)
 
     cmd = ['iam', 'detach-role-policy']


### PR DESCRIPTION
### What is this PR for?
- AWS Elastic Beanstalk Managed Policy Deprecation 이메일을 기준으로 4/15 이후부터 deprecated되는 policy(AWSElasticBeanstalkService)를 새 policy (AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy)로 변경
- AWSElasticBeanstalkService 를 AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy로 변경
- OP 계정의 경우 AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy를 먼저 붙이고 AWSElasticBeanstalkService를 제거필요

### How should this be tested?
- DEV-11414로 EB 환경을 띄웠을때 에러가 없는지 확인
