### PR TITLE
DEV-11568 [HOTFIX] npm 버전 지정.

### DIFF
--- a/_provisioning/provisioning.py
+++ b/_provisioning/provisioning.py
@@ -159,7 +159,7 @@ def _preprocess(hostname):
     env['NVM_DIR'] = '/root/.nvm'
     env['NVM_RC_VERSION'] = ''
     env['PATH'] = ('/root/.nvm/versions/node/%s/bin:' % node_version) + env['PATH']
-    _run(['npm', 'install', '-g', 'npm@latest'])
+    _run(['npm', 'install', '-g', 'npm@6.14.11'])
 
     with open('/root/.bashrc', 'a') as f:
         f.write('export NODE_OPTIONS="--max-old-space-size=2048"\n')


### PR DESCRIPTION
### What is this PR for?
- provisioning.py 의 npm 버전을 6.14.11 로 고정

### How should this be tested?
- vagrant 프로비저닝이 성공적으로 이루어져야 합니다.
- `run_create_s3.py app` 시 성공적으로 aws환경에 웹앱이 프로비저닝되어야 합니다.