### PR TITLE
DEV-11312 cloudwatch alarm에 sachiel, nerv에서 발생하는 예외로그에 대한 알람 추가

### DIFF
--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -446,6 +446,37 @@ def run_create_eb_django(name, settings):
     ################################################################################
     print_message('swap CNAME if the previous version exists')
 
+    if name == 'sachiel':
+        topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
+        if topic_arn:
+            print_message('create cloudwatch log filter for httpd error log')
+
+            cmd = ['logs', 'put-metric-filter']
+            cmd += ['--filter-name', f'{eb_environment_name}_httpd_error_log']
+            cmd += ['--log-group-name', f'/aws/elasticbeanstalk/{eb_environment_name}/var/log/httpd/error_log']
+            cmd += ['--filter-pattern', '']
+            cmd += ['--metric-transformations', f'metricName={eb_environment_name},'
+                                                f'metricNamespace={settings["METRIC_NAME_SPACE"]},'
+                                                f'metricValue=1,'
+                                                f'defaultValue=0']
+            aws_cli.run(cmd, cwd=template_path)
+
+            print_message('create cloudwatch alarm for httpd error log filter')
+
+            cmd = ['cloudwatch', 'put-metric-alarm']
+            cmd += ['--alarm-name', f'{eb_environment_name}_httpd_error_log']
+            cmd += ['--alarm-description', f'{eb_environment_name} httpd error log alarm']
+            cmd += ['--evaluation-periods', '1']
+            cmd += ['--metric-name', eb_environment_name]
+            cmd += ['--namespace', settings["METRIC_NAME_SPACE"]]
+            cmd += ['--statistic', 'Sum']
+            cmd += ['--period', '30']
+            cmd += ['--threshold', '1']
+            cmd += ['--comparison-operator', 'GreaterThanOrEqualToThreshold']
+            cmd += ['--alarm-actions', topic_arn]
+            aws_cli.run(cmd, cwd=template_path)
+
+
     if eb_environment_name_old:
         cmd = ['elasticbeanstalk', 'swap-environment-cnames']
         cmd += ['--source-environment-name', eb_environment_name_old]

--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -446,35 +446,36 @@ def run_create_eb_django(name, settings):
     ################################################################################
     print_message('swap CNAME if the previous version exists')
 
-    if name == 'sachiel':
-        topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
-        if topic_arn:
-            print_message('create cloudwatch log filter for httpd error log')
+    topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
+    if topic_arn:
+        print_message('create cloudwatch log filter for httpd error log')
 
-            cmd = ['logs', 'put-metric-filter']
-            cmd += ['--filter-name', f'{eb_environment_name}_httpd_error_log']
-            cmd += ['--log-group-name', f'/aws/elasticbeanstalk/{eb_environment_name}/var/log/httpd/error_log']
-            cmd += ['--filter-pattern', '']
-            cmd += ['--metric-transformations', f'metricName={eb_environment_name},'
-                                                f'metricNamespace={settings["METRIC_NAME_SPACE"]},'
-                                                f'metricValue=1,'
-                                                f'defaultValue=0']
-            aws_cli.run(cmd, cwd=template_path)
+        metric_name_space = f'{name}ProxyErrorLog'
 
-            print_message('create cloudwatch alarm for httpd error log filter')
+        cmd = ['logs', 'put-metric-filter']
+        cmd += ['--filter-name', f'{eb_environment_name}_httpd_error_log']
+        cmd += ['--log-group-name', f'/aws/elasticbeanstalk/{eb_environment_name}/var/log/httpd/error_log']
+        cmd += ['--filter-pattern', '']
+        cmd += ['--metric-transformations', f'metricName={eb_environment_name},'
+                                            f'metricNamespace={metric_name_space},'
+                                            f'metricValue=1,'
+                                            f'defaultValue=0']
+        aws_cli.run(cmd, cwd=template_path)
 
-            cmd = ['cloudwatch', 'put-metric-alarm']
-            cmd += ['--alarm-name', f'{eb_environment_name}_httpd_error_log']
-            cmd += ['--alarm-description', f'{eb_environment_name} httpd error log alarm']
-            cmd += ['--evaluation-periods', '1']
-            cmd += ['--metric-name', eb_environment_name]
-            cmd += ['--namespace', settings["METRIC_NAME_SPACE"]]
-            cmd += ['--statistic', 'Sum']
-            cmd += ['--period', '30']
-            cmd += ['--threshold', '1']
-            cmd += ['--comparison-operator', 'GreaterThanOrEqualToThreshold']
-            cmd += ['--alarm-actions', topic_arn]
-            aws_cli.run(cmd, cwd=template_path)
+        print_message('create cloudwatch alarm for httpd error log filter')
+
+        cmd = ['cloudwatch', 'put-metric-alarm']
+        cmd += ['--alarm-name', f'{eb_environment_name}_httpd_error_log']
+        cmd += ['--alarm-description', f'{eb_environment_name} httpd error log alarm']
+        cmd += ['--evaluation-periods', '1']
+        cmd += ['--metric-name', eb_environment_name]
+        cmd += ['--namespace', metric_name_space]
+        cmd += ['--statistic', 'Sum']
+        cmd += ['--period', '30']
+        cmd += ['--threshold', '1']
+        cmd += ['--comparison-operator', 'GreaterThanOrEqualToThreshold']
+        cmd += ['--alarm-actions', topic_arn]
+        aws_cli.run(cmd, cwd=template_path)
 
     if eb_environment_name_old:
         cmd = ['elasticbeanstalk', 'swap-environment-cnames']

--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -476,7 +476,6 @@ def run_create_eb_django(name, settings):
             cmd += ['--alarm-actions', topic_arn]
             aws_cli.run(cmd, cwd=template_path)
 
-
     if eb_environment_name_old:
         cmd = ['elasticbeanstalk', 'swap-environment-cnames']
         cmd += ['--source-environment-name', eb_environment_name_old]

--- a/run_create_eb_django_al2.py
+++ b/run_create_eb_django_al2.py
@@ -475,7 +475,6 @@ def run_create_eb_django_al2(name, settings):
             cmd += ['--alarm-actions', topic_arn]
             aws_cli.run(cmd, cwd=template_path)
 
-
     ################################################################################
     print_message('swap CNAME if the previous version exists')
 

--- a/run_create_eb_django_al2.py
+++ b/run_create_eb_django_al2.py
@@ -445,35 +445,36 @@ def run_create_eb_django_al2(name, settings):
 
     subprocess.Popen(['rm', '-rf', './%s' % name], cwd=template_path).communicate()
 
-    if name == 'nerv':
-        topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
-        if topic_arn:
-            print_message('create cloudwatch log filter for nginx error log')
+    topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
+    if topic_arn:
+        print_message('create cloudwatch log filter for nginx error log')
 
-            cmd = ['logs', 'put-metric-filter']
-            cmd += ['--filter-name', f'{eb_environment_name}_nginx_error_log']
-            cmd += ['--log-group-name', f'/aws/elasticbeanstalk/{eb_environment_name}/var/log/nginx/error.log']
-            cmd += ['--filter-pattern', '']
-            cmd += ['--metric-transformations', f'metricName={eb_environment_name},'
-                                                f'metricNamespace={settings["METRIC_NAME_SPACE"]},'
-                                                f'metricValue=1,'
-                                                f'defaultValue=0']
-            aws_cli.run(cmd, cwd=template_path)
+        metric_name_space = f'{name}ProxyErrorLog'
 
-            print_message('create cloudwatch alarm for nginx error log filter')
+        cmd = ['logs', 'put-metric-filter']
+        cmd += ['--filter-name', f'{eb_environment_name}_nginx_error_log']
+        cmd += ['--log-group-name', f'/aws/elasticbeanstalk/{eb_environment_name}/var/log/nginx/error.log']
+        cmd += ['--filter-pattern', '']
+        cmd += ['--metric-transformations', f'metricName={eb_environment_name},'
+                                            f'metricNamespace={metric_name_space},'
+                                            f'metricValue=1,'
+                                            f'defaultValue=0']
+        aws_cli.run(cmd, cwd=template_path)
 
-            cmd = ['cloudwatch', 'put-metric-alarm']
-            cmd += ['--alarm-name', f'{eb_environment_name}_nginx_error_log']
-            cmd += ['--alarm-description', f'{eb_environment_name} nginx error log alarm']
-            cmd += ['--evaluation-periods', '1']
-            cmd += ['--metric-name', eb_environment_name]
-            cmd += ['--namespace', settings["METRIC_NAME_SPACE"]]
-            cmd += ['--statistic', 'Sum']
-            cmd += ['--period', '30']
-            cmd += ['--threshold', '1']
-            cmd += ['--comparison-operator', 'GreaterThanOrEqualToThreshold']
-            cmd += ['--alarm-actions', topic_arn]
-            aws_cli.run(cmd, cwd=template_path)
+        print_message('create cloudwatch alarm for nginx error log filter')
+
+        cmd = ['cloudwatch', 'put-metric-alarm']
+        cmd += ['--alarm-name', f'{eb_environment_name}_nginx_error_log']
+        cmd += ['--alarm-description', f'{eb_environment_name} nginx error log alarm']
+        cmd += ['--evaluation-periods', '1']
+        cmd += ['--metric-name', eb_environment_name]
+        cmd += ['--namespace', metric_name_space]
+        cmd += ['--statistic', 'Sum']
+        cmd += ['--period', '30']
+        cmd += ['--threshold', '1']
+        cmd += ['--comparison-operator', 'GreaterThanOrEqualToThreshold']
+        cmd += ['--alarm-actions', topic_arn]
+        aws_cli.run(cmd, cwd=template_path)
 
     ################################################################################
     print_message('swap CNAME if the previous version exists')

--- a/run_terminate_eb.py
+++ b/run_terminate_eb.py
@@ -37,6 +37,15 @@ def run_terminate_environment(name):
                 cmd += ['--environment-name', r['EnvironmentName']]
                 aws_cli.run(cmd, ignore_error=True)
 
+                if 'nerv' in r['EnvironmentName']:
+                    cmd = ['cloudwatch', 'delete-alarms']
+                    cmd += ['--alarm-names', f'{r["EnvironmentName"]}_nginx_error_log']
+                    aws_cli.run(cmd, ignore_error=True)
+                if 'sachiel' in r['EnvironmentName']:
+                    cmd = ['cloudwatch', 'delete-alarms']
+                    cmd += ['--alarm-names', f'{r["EnvironmentName"]}_httpd_error_log']
+                    aws_cli.run(cmd, ignore_error=True)
+
         if count == 0:
             break
 

--- a/run_terminate_eb.py
+++ b/run_terminate_eb.py
@@ -37,14 +37,13 @@ def run_terminate_environment(name):
                 cmd += ['--environment-name', r['EnvironmentName']]
                 aws_cli.run(cmd, ignore_error=True)
 
-                if 'nerv' in r['EnvironmentName']:
-                    cmd = ['cloudwatch', 'delete-alarms']
-                    cmd += ['--alarm-names', f'{r["EnvironmentName"]}_nginx_error_log']
-                    aws_cli.run(cmd, ignore_error=True)
-                if 'sachiel' in r['EnvironmentName']:
-                    cmd = ['cloudwatch', 'delete-alarms']
-                    cmd += ['--alarm-names', f'{r["EnvironmentName"]}_httpd_error_log']
-                    aws_cli.run(cmd, ignore_error=True)
+                cmd = ['cloudwatch', 'delete-alarms']
+                cmd += ['--alarm-names', f'{r["EnvironmentName"]}_nginx_error_log']
+                aws_cli.run(cmd, ignore_error=True)
+
+                cmd = ['cloudwatch', 'delete-alarms']
+                cmd += ['--alarm-names', f'{r["EnvironmentName"]}_httpd_error_log']
+                aws_cli.run(cmd, ignore_error=True)
 
         if count == 0:
             break

--- a/run_terminate_eb_old_environment.py
+++ b/run_terminate_eb_old_environment.py
@@ -78,6 +78,15 @@ for vpc_env in env['vpc']:
         if not _is_old_environment(r['CNAME']):
             continue
 
+        if 'nerv' in r['EnvironmentName']:
+            cmd = ['cloudwatch', 'delete-alarms']
+            cmd += ['--alarm-names', f'{r["EnvironmentName"]}_nginx_error_log']
+            aws_cli.run(cmd, ignore_error=True)
+        if 'sachiel' in r['EnvironmentName']:
+            cmd = ['cloudwatch', 'delete-alarms']
+            cmd += ['--alarm-names', f'{r["EnvironmentName"]}_httpd_error_log']
+            aws_cli.run(cmd, ignore_error=True)
+
         cmd = ['elasticbeanstalk', 'terminate-environment']
         cmd += ['--environment-name', r['EnvironmentName']]
         aws_cli.run(cmd, ignore_error=True)

--- a/run_terminate_eb_old_environment.py
+++ b/run_terminate_eb_old_environment.py
@@ -78,14 +78,13 @@ for vpc_env in env['vpc']:
         if not _is_old_environment(r['CNAME']):
             continue
 
-        if 'nerv' in r['EnvironmentName']:
-            cmd = ['cloudwatch', 'delete-alarms']
-            cmd += ['--alarm-names', f'{r["EnvironmentName"]}_nginx_error_log']
-            aws_cli.run(cmd, ignore_error=True)
-        if 'sachiel' in r['EnvironmentName']:
-            cmd = ['cloudwatch', 'delete-alarms']
-            cmd += ['--alarm-names', f'{r["EnvironmentName"]}_httpd_error_log']
-            aws_cli.run(cmd, ignore_error=True)
+        cmd = ['cloudwatch', 'delete-alarms']
+        cmd += ['--alarm-names', f'{r["EnvironmentName"]}_nginx_error_log']
+        aws_cli.run(cmd, ignore_error=True)
+
+        cmd = ['cloudwatch', 'delete-alarms']
+        cmd += ['--alarm-names', f'{r["EnvironmentName"]}_httpd_error_log']
+        aws_cli.run(cmd, ignore_error=True)
 
         cmd = ['elasticbeanstalk', 'terminate-environment']
         cmd += ['--environment-name', r['EnvironmentName']]


### PR DESCRIPTION
### What is this PR for?
httpd, nginx exception 등은 알람 메일로 수집이 안되기 때문에 cloudwatch log에 알람 설정 추가 필요 

참고 사이트 : https://theithollow.com/2017/12/11/use-amazon-cloudwatch-logs-metric-filters-send-alerts/

- sachiel, nerv 서버에 대한 처리 필요
    - /aws/elasticbeanstalk/nerv-*/var/log/nginx/error.log
    - /aws/elasticbeanstalk/sachiel-*/var/log/httpd/error_log

관련 PR
https://github.com/HardBoiledSmith/magi/pull/749

### How should this be tested?
- 위 관련 PR magi DEV-11312에서 config.json을 생성해 주세요.
- johhanna에서 ./run.py create_iam, vpc, rds를 띄어주세요.
- /run_create_ec2_client_vpn.py를 실행 후 ovpn을 발급받아주세요.
- 발급완료 후 rds에 데이터를 넣어주세요.
- ./run.py create_sqs , create_sns를 실행해 주세요.
- 해당 브랜치의 ./run_create_eb.py sachiel과 ./run_create_eb.py nerv를 실행해 주세요.
- ./run_create_lambda.py cloudwatch_send_alarm 을 실행 해 주세요.

app console에 접속하여 cloudwatch 서비스로 접속 해주세요.
- /aws/elasticbeanstalk/nerv-*/var/log/nginx/error.log
- /aws/elasticbeanstalk/sachiel-*/var/log/httpd/error_log
위 두 로그 그룹에 대해서 filter와 cloudwatch alarm이 SNS(cloudwatch-alarm)으로 걸려있는지 확인해주세요. 

eb create에 넣은 이유는 eb가 생성된 이 후 filter를 설정해야 하고, cloudwatch alarm을 걸어주어야 하여 create에 지정하였습니다.
terminate_eb와 old_eb 두 군대에 넣은 이유는 cloudwatch에 걸어둔 filter의 경우 eb가 정리되며 삭제가 되지만, cloudwatch alarm의 경우 자동으로 삭제 되지 않아 cron으로 old_eb_termiante 할 때와 eb_terminate 두 군대 넣어두었습니다.

### Screenshots (if appropriate)
cloudwatch 알람이 적용 된 이후 sns 토픽으로 지정된 lambda로 발송
nerv = nginx_error_log, sachiel = httpd_error_log
![image](https://user-images.githubusercontent.com/42234701/113574323-cddb7e80-9656-11eb-9460-2d55f457febc.png)


old_eb 종료
![image](https://user-images.githubusercontent.com/42234701/113574071-560d5400-9656-11eb-8b54-9eafb15052b3.png)
App console EB
![image](https://user-images.githubusercontent.com/42234701/113574242-a84e7500-9656-11eb-9315-c73953117103.png)

old 종료 후 남은 cloudwatch alarm ( 떠있는 신형 instance만 alarm 존재함 확인)
![image](https://user-images.githubusercontent.com/42234701/113574523-3d516e00-9657-11eb-8fcf-ca08b9bc94e3.png)


eb_terminate 실행 시 (모든 eb관련 cloudwatch alarm은 제거)
![image](https://user-images.githubusercontent.com/42234701/113574182-8f45c400-9656-11eb-820e-500f8e86c7a1.png)
