### PR TITLE
DEV-11712 gendo.exe.config 의존성 제거

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -178,21 +178,6 @@ def run_create_eb_windows(name, settings):
     write_file(
         f'{template_path}/{name}/_provisioning/configuration/Users/vagrant/Desktop/{name}_exe/settings_local.py', lines)
 
-    lines = read_file(f'{template_path}/{name}/_provisioning/configuration/'
-                      f'Users/vagrant/Desktop/{name}_exe/{name}.exe_sample.config')
-    option_list = list()
-    option_list.append(['PHASE', phase])
-    for key in settings:
-        value = settings[key]
-        option_list.append([key, value])
-    for oo in option_list:
-        if oo[0] == 'SENTRY_DSN':
-            lines = re_sub_lines(lines, '^.+Dsn value=.+$', f'<Dsn value="{oo[1]}" />')
-        else:
-            lines = re_sub_lines(lines, f'^.+add key=\"({oo[0]})\" value=.+$', f'<add key="\\1" value="{oo[1]}" />')
-    write_file(f'{template_path}/{name}/_provisioning/configuration/'
-               f'Users/vagrant/Desktop/{name}_exe/{name}.exe.config', lines)
-
     ################################################################################
     print_message('download artifact')
 


### PR DESCRIPTION
### What is this PR for?
- https://hbsmith.atlassian.net/browse/DEV-11712 문제는 gendo.exe.config 의존에 따라 생기는 걸로 파악중
- gendo 바이너리 빌드시 gendo.exe.config내에 아래와 같이 어셈블리 버전 정보가 자동으로 포함이 되는데 johanna에서 이 부분이 제거된 파일로 강제로 덮어 씌워버리고, 이에 의해 잘못된 버전을 레퍼런스 하는 문제가 발생되는걸로 추정됨
```
<runtime>
    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
      <dependentAssembly>
        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
      </dependentAssembly>
    </assemblyBinding>
```
- johanna 에서 gendo.exe.config를 덮어씌우는 코드를 제거하여 문제를 해결시도함