### PR TITLE
DEV-12492 set root volume for EB instance as GP3

### DIFF
--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -308,6 +308,12 @@ def run_create_eb_django(name, settings):
     option_settings.append(oo)
 
     oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:launchconfiguration'
+    oo['OptionName'] = 'RootVolumeType'
+    oo['Value'] = 'gp3'
+    option_settings.append(oo)
+
+    oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'AssociatePublicIpAddress'
     oo['Value'] = 'false'

--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -300,6 +300,12 @@ def run_create_eb_windows(name, settings):
     option_settings.append(oo)
 
     oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:launchconfiguration'
+    oo['OptionName'] = 'RootVolumeType'
+    oo['Value'] = 'gp3'
+    option_settings.append(oo)
+
+    oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'AssociatePublicIpAddress'
     oo['Value'] = 'false'


### PR DESCRIPTION
### What is this PR for?
- EBS 볼륨 타입으로 gp2 대비 20% 정도의 비용절감 효과가 있는 GP3 도입 (https://ahmedahamid.com/which-is-better/)
- 참고: https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-autoscalinglaunchconfiguration

### How should this be tested?
- DEV-12492로 EB 인스턴스 생성후 Root Volume 타입이 GP3로 변경되었음을 확인

