### PR TITLE
DEV-12423 increase timeout 120 -> 240

### DIFF
--- a/run_create_lambda_sqs.py
+++ b/run_create_lambda_sqs.py
@@ -141,7 +141,7 @@ def run_create_lambda_sqs(function_name, settings):
                '--role', role_arn,
                '--handler', 'lambda.handler',
                '--runtime', 'python3.7',
-               '--timeout', '120']
+               '--timeout', '240']
         aws_cli.run(cmd, cwd=deploy_folder)
 
         print_message('update lambda tags')
@@ -182,7 +182,7 @@ def run_create_lambda_sqs(function_name, settings):
            '--handler', 'lambda.handler',
            '--runtime', 'python3.7',
            '--tags', ','.join(tags),
-           '--timeout', '120']
+           '--timeout', '240']
     aws_cli.run(cmd, cwd=deploy_folder)
 
     print_message('give event permission')


### PR DESCRIPTION
### What is this PR for?
- sachiel_batch_result 람다의 제한시간이 2분(120초)으로 설정되어 있눈대 종종 이를 넘겨서 에러가 발생하는 문제 해소 (스샷참고)
- 이 경우 timeout 이 발생했다는 로그가 남고 lambda가 종료되어 버림
<img width="1096" alt="Screen Shot 2021-07-21 at 12 24 03 AM" src="https://user-images.githubusercontent.com/1650254/126351364-2fecb4e3-a514-4a35-9c22-0089afbe28b4.png">
- 2분을 두배인 4로 업그레이드 (120초 -> 240초)

### How should this be tested?
- 위 PR 배포후 cloudwatch 그래프가 240초 미만으로 실행됨을 확인
