### PR TITLE
DEV-12525 Change ACM validation method (email -> DNS)

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -365,6 +365,11 @@ class AWSCli:
 
         for cl in result['CertificateSummaryList']:
             if cl['DomainName'] == domain:
+
+                # TODO: remove this hack after path DEV-1252 complete
+                if env['common']['PHASE'] == 'op' and not cl['CertificateArn'].endswith('224'):
+                    continue
+
                 return cl['CertificateArn']
 
         raise Exception()


### PR DESCRIPTION
### What is this PR for?

- https://aws.amazon.com/premiumsupport/knowledge-center/switch-acm-certificate/ 에 의거하여 ACM 인증서의 인증 방식을 email에서 DNS로 변경
- Route53에 관련 DNS 레코드는 8/10에 추가완료
- https://github.com/HardBoiledSmith/magi/pull/797 와 연관이슈
- https://hbsmith.atlassian.net/browse/DEV-12341 OP 패치 이후 본 hack 제거

### How should this be tested?

- OP EB 패치시 ARN 끝자리가 224로 끝나는 acm 인증서 (DNS 인증)을 정상적으로 이용 가능한지 확인
