### PR TITLE
DEV-12944 AWS 모니터링 툴 + Pager Duty 연동

### DIFF
--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+import json
+from datetime import datetime
+import time
+
+from run_common import AWSCli
+from run_common import parse_args
+from env import env
+from run_common import print_message
+
+
+def create_route53_health_check(settings):
+
+    aws_cli = AWSCli()
+    name = settings['NAME']
+
+    cmd = ['route53', 'create-health-check']
+    timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M')
+    caller_reference = f'{name}-{timestamp}'
+    cmd += ['--caller-reference', caller_reference]
+
+    dd = {
+        "Port": 443,
+        "Type": "HTTPS",
+        "ResourcePath": settings['RESOURCEPATH'],
+        "FullyQualifiedDomainName": settings['TARGETDOMAINNAME'],
+        "RequestInterval": 30,
+        "FailureThreshold": 3,
+        "MeasureLatency": False,
+        "Inverted": False,
+        "Disabled": False,
+        "EnableSNI": True,
+        "Regions": ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2",
+                    "ap-northeast-1", "sa-east-1"]
+    }
+
+    cmd += ['--health-check-config', json.dumps(dd)]
+    rr = aws_cli.run(cmd)
+    print(rr)
+
+    healthcheck_id = rr['HealthCheck']['Id']
+    cmd = ['route53', 'change-tags-for-resource']
+    cmd += ['--resource-id', healthcheck_id]
+    cmd += ['--resource-type', 'healthcheck']
+    cmd += ['--add-tags', f'Key=Name,Value={caller_reference}']
+    aws_cli.run(cmd)
+
+    healthcheck_region = 'us-east-1'
+    aws_cli = AWSCli(healthcheck_region)
+
+    alarm_name = f'{name}-{healthcheck_region}-{settings["METRIC_NAME"]}'
+    print_message('create or update cloudwatch alarm: %s' % alarm_name)
+
+    time.sleep(5)
+
+    topic_arn = aws_cli.get_topic_arn(settings['SNS_TOPIC_NAME'])
+    if not topic_arn:
+        print(f'sns topic: "{settings["SNS_TOPIC_NAME"]}" is not exists in us-east-1')
+        raise Exception()
+
+    cmd = ['cloudwatch', 'put-metric-alarm']
+    cmd += ['--alarm-actions', topic_arn]
+    cmd += ['--alarm-description', settings['DESCRIPTION']]
+    cmd += ['--alarm-name', alarm_name]
+    cmd += ['--comparison-operator', settings['COMPARISON_OPERATOR']]
+    cmd += ['--datapoints-to-alarm', settings['DATAPOINTS_TO_ALARM']]
+    cmd += ['--dimensions', f'Name=HealthCheckId,Value={healthcheck_id}']
+    cmd += ['--evaluation-periods', settings['EVALUATION_PERIODS']]
+    cmd += ['--metric-name', settings['METRIC_NAME']]
+    cmd += ['--namespace', settings['NAMESPACE']]
+    cmd += ['--period', settings['PERIOD']]
+    cmd += ['--statistic', settings['STATISTIC']]
+    cmd += ['--threshold', settings['THRESHOLD']]
+    if 'INSUFFICIENT_DATA_ACTIONS' in settings:
+        cmd += ['--treat-missing-data', settings['INSUFFICIENT_DATA_ACTIONS']]
+    aws_cli.run(cmd)
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+if __name__ == '__main__':
+    args = parse_args()
+
+    for settings in env.get('route53', list()):
+
+        create_route53_health_check(settings)

--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -31,7 +31,7 @@ def create_route53_health_check(settings):
         "Inverted": False,
         "Disabled": False,
         "EnableSNI": True,
-        "Regions": ["us-east-1", "us-west-1", "ap-southeast-1"]
+        "Regions": ["ap-northeast-1", "us-east-1", "ap-southeast-2"]
     }
 
     cmd += ['--health-check-config', json.dumps(dd)]

--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -11,9 +11,9 @@ from run_common import print_message
 
 
 def create_route53_health_check(settings):
-
     aws_cli = AWSCli()
     name = settings['NAME']
+    print_message('create Route53 health check: %s' % name)
 
     cmd = ['route53', 'create-health-check']
     timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M')
@@ -37,7 +37,6 @@ def create_route53_health_check(settings):
 
     cmd += ['--health-check-config', json.dumps(dd)]
     rr = aws_cli.run(cmd)
-    print(rr)
 
     healthcheck_id = rr['HealthCheck']['Id']
     cmd = ['route53', 'change-tags-for-resource']

--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -31,8 +31,7 @@ def create_route53_health_check(settings):
         "Inverted": False,
         "Disabled": False,
         "EnableSNI": True,
-        "Regions": ["us-east-1", "us-west-1", "us-west-2", "eu-west-1", "ap-southeast-1", "ap-southeast-2",
-                    "ap-northeast-1", "sa-east-1"]
+        "Regions": ["us-east-1", "us-west-1", "ap-southeast-1"]
     }
 
     cmd += ['--health-check-config', json.dumps(dd)]

--- a/run_create_sns.py
+++ b/run_create_sns.py
@@ -31,8 +31,8 @@ def run_create_sns_topic(name, settings):
         cmd += ['--notification-endpoint', settings['EMAIL']]
         aws_cli.run(cmd)
 
-    if 'PAGERDUTYAPPKEY' in settings and settings['PAGERDUTYAPPKEY']:
-        print_message(f'create an email subscription for sns topic: {name}')
+    if settings.get('PAGERDUTYAPPKEY'):
+        print_message(f'create an pagerduty subscription for sns topic: {name}')
         cmd = ['sns', 'subscribe']
         cmd += ['--topic-arn', result['TopicArn']]
         cmd += ['--protocol', 'https']

--- a/run_create_sns.py
+++ b/run_create_sns.py
@@ -31,6 +31,14 @@ def run_create_sns_topic(name, settings):
         cmd += ['--notification-endpoint', settings['EMAIL']]
         aws_cli.run(cmd)
 
+    if 'PAGERDUTYAPPKEY' in settings and settings['PAGERDUTYAPPKEY']:
+        print_message(f'create an email subscription for sns topic: {name}')
+        cmd = ['sns', 'subscribe']
+        cmd += ['--topic-arn', result['TopicArn']]
+        cmd += ['--protocol', 'https']
+        cmd += ['--notification-endpoint', settings['PAGERDUTYAPPKEY']]
+        aws_cli.run(cmd)
+
 
 ################################################################################
 #

--- a/run_terminate_route53_health_check.py
+++ b/run_terminate_route53_health_check.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from env import env
+from run_common import AWSCli
+from run_common import parse_args
+
+
+def delete_route53_health_check(settings):
+    aws_cli = AWSCli()
+    name = settings['NAME']
+
+    cmd = ['route53', 'list-health-checks']
+    rr = aws_cli.run(cmd)
+
+    for r in rr['HealthChecks']:
+        if r['CallerReference'].startswith(name):
+            cmd = ['route53', 'delete-health-check']
+            cmd += ['--health-check-id', r['Id']]
+            aws_cli.run(cmd)
+
+            healthcheck_region = 'us-east-1'
+            aws_cli = AWSCli(healthcheck_region)
+            alarm_name = f'{name}-{healthcheck_region}-{settings["METRIC_NAME"]}'
+            cmd = ['cloudwatch', 'delete-alarms']
+            cmd += ['--alarm-names', alarm_name]
+            aws_cli.run(cmd)
+
+
+################################################################################
+#
+# start
+#
+################################################################################
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    for settings in env.get('route53', list()):
+        delete_route53_health_check(settings)


### PR DESCRIPTION
### What is this PR for?
[AS-IS]
- AWS 자원 중 landing page, hbsmith web, sachiel, gedno에 대해 모니터링을 하기 위한 작업.

[TO-BE]
- 공개 망에 노출된 자원은 route53 health check 서비스를 통해 주기적으로 요청을 보내 이상이 생겼을 시 알림을 줌.
- Gendo같은 private자원은 별도의 cloud watch의 데이터 기준으로 이상을 체크.

알림의 순서는 cloudwatch -> sns -> pagerduty -> statuspage

### How should this be tested?
- 개인 세팅은 AWS 자원까지만 해당하며, Pageduty, Statuspage는 별도의 QA, DV를 위해 개설된 것은 없습니다. 따라서, PAGERDUTY키는 따로 설정하지 않고 작성하도록 하겠습니다.
- 해당 브랜치의 johanna, magi의 config 파일을 풀어주세요.
- magi에 각 개인별 -variable파일에 아래의 값을 추가해 주어야 합니다.
```
"PAGEDUTYAPPKEY_HBSMITH_WEB": "",
"PAGEDUTYAPPKEY_GENDO": "",
"PAGEDUTYAPPKEY_LANDING_PAGE": "",
"PAGEDUTYAPPKEY_SACHIEL": "",
"ROUTE53_HEALTH_CHECK_TARGET_DOMAIN_SACHIEL": "",
"ROUTE53_HEALTH_CHECK_TARGET_DOMAIN_HBSMITH_WEB": "",
"ROUTE53_HEALTH_CHECK_TARGET_DOMAIN_LANDING_PAGE": ""
 ``` 
- ROUTE53_HEALTH_CHECK_TARGET_DOMAIN... 의 값 3개는 테스트를 위해 OP환경에 서비스 되고있는 URL을 사용하면 됩니다.
```
  "ROUTE53_HEALTH_CHECK_TARGET_DOMAIN_SACHIEL": "op-sachiel.hbsmith.io",
  "ROUTE53_HEALTH_CHECK_TARGET_DOMAIN_HBSMITH_WEB": "app.hbsmith.io",
  "ROUTE53_HEALTH_CHECK_TARGET_DOMAIN_LANDING_PAGE": "www.hbsmith.io",
```
- ./run.py create_sns을 실행 후  ./run_create_route53_health_check.py 를 실행시켜주세요.
- AWS CONSOLE에 접속하여 SNS 및 Cloudwatch를 확인했을떄 아래의 사진과 같이 세팅이 되어있어야 합니다.
![image](https://user-images.githubusercontent.com/42234701/133566412-1505c07f-f47b-4168-8864-7108b1a5fd46.png)
![image](https://user-images.githubusercontent.com/42234701/133566498-c9057a8a-16a1-44c5-881a-dc7df75aeea1.png)

- Gendo의 경우는 기존의 topic명만 변경하였음으로 추가 테스트는 진행하지 않았습니다.
