### PR TITLE
DEV-13352 gendo: EB에서 AWSCLI 관련 에러(Access violation)발생 원인파악 AWS CLI2 직접 설치로 변경.

### DIFF
--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -105,15 +105,6 @@ def run_create_image_builder(options):
     recipe_component['componentArn'] = gendo_component_arn
     recipe_components.append(recipe_component)
 
-    cmd = ['imagebuilder', 'list-components']
-    cmd += ['--owner', 'Amazon']
-    cmd += ['--filters', 'name=name,values="aws-cli-version-2-windows"']
-    rr = aws_cli.run(cmd)
-    recipe_component = dict()
-    arn = rr['componentVersionList'][-1]['arn']
-    recipe_component['componentArn'] = arn
-    recipe_components.append(recipe_component)
-
     cmd = ['ec2', 'describe-images']
     cmd += ['--owner', 'amazon']
     cmd += ['--filters',


### PR DESCRIPTION
### What is this PR for?
- 기존 Gendo Image는 AWS CLI v2 설치를 이미지 빌더의 AWS에서 제공하는 component로 설치하는 형태 
- AWS 제공하는 Component가 우리가 모르는 부분을 설정함으로써 생기는 문제일 수 있어 직접 설치하는 방향으로 변경.

**연관 PR**
https://github.com/HardBoiledSmith/gendo/pull/774

### How should this be tested?
- johanna에서 ./run_create_imagebuilder_gendo.py -b DEV-13352 를 실행해주세요.
- aws console에 접속하여 imgaebuilder 서비스로 들어가주세요.
- 실행한 스크립트의 이미지가 에러 없이 생성이 되어야 합니다.
