### PR TITLE
DEV-13555 sachiel-*_nginx_error_log: .git 경로에 대한 공격 방어 성공은 pg알람에서 제외

### DIFF
--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -478,7 +478,7 @@ def run_create_eb_django(name, settings, options):
         cmd = ['logs', 'put-metric-filter']
         cmd += ['--filter-name', f'{eb_environment_name}_nginx_error_log']
         cmd += ['--log-group-name', f'/aws/elasticbeanstalk/{eb_environment_name}/var/log/nginx/error.log']
-        cmd += ['--filter-pattern', '']
+        cmd += ['--filter-pattern', '- "access forbidden by rule"']
         cmd += ['--metric-transformations', f'metricName={eb_environment_name},'
                                             f'metricNamespace={metric_name_space},'
                                             f'metricValue=1,'


### PR DESCRIPTION
### What is this PR for?

- .git 경로에 대한 공격시도를 nginx 측에서 차단하기 위해 rule을 추가하였으나 해당 rule이 발생시키는 정보로그에 의해 PagerDuty alarm 발생
- 공격 방어가 성공적으로 이루어졌기 때문에 해당 로그를 metric filter에서 제외

### How should this be tested?

- AWS 환경에서 테스트
- sachiel, nerv 둘중 하나를 프로비저닝
- sachiel, nerv에 대해서 `GET /.git/gitconfig` 등으로 조회시도
- 402 access denied 가 응답으로 오는지 확인
- Cloudwatch 또는 PD에서 관련 알람이 떨어지지 않음
