### PR TITLE
DEV-13834 Apple Silicon (aarch64) 지원 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 .vagrant
 /.idea
 id_rsa
+id_ed25519
 template/

--- a/_provisioning/Vagrantfile
+++ b/_provisioning/Vagrantfile
@@ -2,7 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "hbsmith/awslinux2"
+  if ENV["ARCH"] != "arm64"
+    config.vm.box = "hbsmith/awslinux2"
+  else
+    config.vm.box = "hbsmith/fedora-35-aarch64"
+  end
 
   config.vm.provider "parallels" do |prl|
     prl.name = 'hbsmith-johanna'
@@ -11,9 +15,16 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.provision "file", source: "../config.json", destination: "/vagrant/opt/johanna/config.json"
-  config.vm.provision "shell", inline: "amazon-linux-extras enable python3.8"
-  config.vm.provision "shell", inline: "yum -y install python38 python38-devel"
-  config.vm.provision "shell", inline: "update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1"
+
+  if config.vm.box == "hbsmith/awslinux2"
+    config.vm.provision "shell", inline: "amazon-linux-extras enable python3.8"
+    config.vm.provision "shell", inline: "yum -y install python38 python38-devel"
+    config.vm.provision "shell", inline: "update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1"
+  else
+    config.vm.provision "shell", inline: "dnf -y install python3.8"
+    config.vm.provision "shell", inline: "python3.8 -m ensurepip --user"
+  end
+
   config.vm.provision "shell", path: "provisioning.py", env: { "BRANCH" => ENV["BRANCH"] }, reboot: true
   config.vm.network "private_network", ip: "192.168.124.5"
 end


### PR DESCRIPTION
### What is this PR for?

- Apple Silicon에서도 프로비저닝 및 이용 가능하도록 프로비저닝 코드를 재구성
- ARM64에선 https://app.vagrantup.com/hbsmith/boxes/fedora-35-aarch64를 이용하도록 구성
- x86 환경에선 기존과 동일하게 https://app.vagrantup.com/hbsmith/boxes/awslinux2 를 이용하도록 구성

### How should this be tested?

- `ARCH=arm64 vagrant up`으로 M1 Mac에서 프로비저닝 정상 수행되는지 확인
- 기존 x86 맥에선 `vagrant up`하면 프로비저닝이 정상 수행되는지 확인
