### PR TITLE
johanna, gendo : imagebuilder gendo image 스크립트 수정 ( component 16,000자 제한으로 인해 파일 2개로 분리)

### DIFF
--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -77,8 +77,6 @@ def run_create_image_builder(options):
 
     print_session('create component')
 
-    gendo_component_name = f'gendo_provisioning_component_{str_timestamp}'
-
     file_path_name = 'template/gendo/gendo/requirements.txt'
     tmp_lines = read_file(file_path_name)
     lines = list()
@@ -107,6 +105,7 @@ def run_create_image_builder(options):
     git_hash_gendo_tag = f"git_hash_{name}={git_hash_app.decode('utf-8').strip()}"
     eb_platform_version_tag = f'eb_platform={eb_platform_version}'
 
+    gendo_component_name = f'gendo_provisioning_part1_component_{str_timestamp}'
     cmd = ['imagebuilder', 'create-component']
     cmd += ['--name', gendo_component_name]
     cmd += ['--semantic-version', semantic_version]
@@ -118,6 +117,7 @@ def run_create_image_builder(options):
     rr = aws_cli.run(cmd)
     gendo_component_arn1 = rr['componentBuildVersionArn']
 
+    gendo_component_name = f'gendo_provisioning_part2_component_{str_timestamp}'
     cmd = ['imagebuilder', 'create-component']
     cmd += ['--name', gendo_component_name]
     cmd += ['--semantic-version', semantic_version]
@@ -137,6 +137,8 @@ def run_create_image_builder(options):
     recipe_component = dict()
     recipe_component['componentArn'] = gendo_component_arn1
     recipe_components.append(recipe_component)
+
+    recipe_component = dict()
     recipe_component['componentArn'] = gendo_component_arn2
     recipe_components.append(recipe_component)
 

--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -92,10 +92,10 @@ def run_create_image_builder(options):
     copyfile('template/gendo/gendo/_provisioning/gendo_image_provisioning_part1_sample.yml',
              'template/gendo/gendo/_provisioning/gendo_image_provisioning_part1.yml')
 
-    sample2_filename_path = 'template/gendo/gendo/_provisioning/gendo_image_provisioning_part2_sample.yml'
+    sample_filename_path = 'template/gendo/gendo/_provisioning/gendo_image_provisioning_part2_sample.yml'
     filename_path = 'template/gendo/gendo/_provisioning/gendo_image_provisioning_part2.yml'
     with open(filename_path, 'w') as ff:
-        with open(sample2_filename_path, 'r') as f:
+        with open(sample_filename_path, 'r') as f:
             tmp_list = f.readlines()
             for line in tmp_list:
                 if 'REQUIREMENTS.TXT' in line:

--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -4,8 +4,8 @@ import os
 import subprocess
 import time
 from datetime import datetime
-
 from pytz import timezone
+from shutil import copyfile
 
 from run_common import AWSCli
 from run_common import print_message
@@ -89,10 +89,13 @@ def run_create_image_builder(options):
         lines.append(tt)
     pp = ''.join(lines)
 
-    sample_filename_path = 'template/gendo/gendo/_provisioning/gendo_image_sample.yml'
-    filename_path = 'template/gendo/gendo/_provisioning/gendo_image.yml'
+    copyfile('template/gendo/gendo/_provisioning/gendo_image_provisioning_part1_sample.yml',
+             'template/gendo/gendo/_provisioning/gendo_image_provisioning_part1.yml')
+
+    sample2_filename_path = 'template/gendo/gendo/_provisioning/gendo_image_provisioning_part2_sample.yml'
+    filename_path = 'template/gendo/gendo/_provisioning/gendo_image_provisioning_part2.yml'
     with open(filename_path, 'w') as ff:
-        with open(sample_filename_path, 'r') as f:
+        with open(sample2_filename_path, 'r') as f:
             tmp_list = f.readlines()
             for line in tmp_list:
                 if 'REQUIREMENTS.TXT' in line:
@@ -110,10 +113,21 @@ def run_create_image_builder(options):
     cmd += ['--platform', 'Windows']
     cmd += ['--supported-os-versions', 'Microsoft Windows Server 2016']
     cmd += ['--tags', f'{git_hash_johanna_tag},{git_hash_gendo_tag},{eb_platform_version_tag}']
-    cmd += ['--data', 'file://template/gendo/gendo/_provisioning/gendo_image.yml']
+    cmd += ['--data', 'file://template/gendo/gendo/_provisioning/gendo_image_provisioning_part1.yml']
 
     rr = aws_cli.run(cmd)
-    gendo_component_arn = rr['componentBuildVersionArn']
+    gendo_component_arn1 = rr['componentBuildVersionArn']
+
+    cmd = ['imagebuilder', 'create-component']
+    cmd += ['--name', gendo_component_name]
+    cmd += ['--semantic-version', semantic_version]
+    cmd += ['--platform', 'Windows']
+    cmd += ['--supported-os-versions', 'Microsoft Windows Server 2016']
+    cmd += ['--tags', f'{git_hash_johanna_tag},{git_hash_gendo_tag},{eb_platform_version_tag}']
+    cmd += ['--data', 'file://template/gendo/gendo/_provisioning/gendo_image_provisioning_part2.yml']
+
+    rr = aws_cli.run(cmd)
+    gendo_component_arn2 = rr['componentBuildVersionArn']
 
     ############################################################################
     print_session('create recipe')
@@ -121,7 +135,9 @@ def run_create_image_builder(options):
     recipe_components = list()
 
     recipe_component = dict()
-    recipe_component['componentArn'] = gendo_component_arn
+    recipe_component['componentArn'] = gendo_component_arn1
+    recipe_components.append(recipe_component)
+    recipe_component['componentArn'] = gendo_component_arn2
     recipe_components.append(recipe_component)
 
     cmd = ['ec2', 'describe-images']


### PR DESCRIPTION
### What is this PR for?
-  image builder에서 gendo image 파이프라인 구축을 위해 필요한 것 중 한 개인 component 요소에서 에러가 발생
- 원인 : 한개의 component( .yml ) 파일에는 16000자 제한
- 해결 방안: component를 둘로 쪼개어 설치를 진행