### PR TITLE
DEV-14893 Fedora 3.3 이상 버전에서 nameserver resolver 동작 이슈 해결

### DIFF
--- a/_provisioning/provisioning.py
+++ b/_provisioning/provisioning.py
@@ -80,6 +80,8 @@ def _preprocess(hostname):
 
     if platform.processor() == 'aarch64':
         _run(['sudo', 'hostnamectl', 'set-hostname', hostname])
+        _run(['sudo', 'systemctl', 'stop', 'systemd-resolved.service'])
+        _run(['sudo', 'systemctl', 'disable', 'systemd-resolved.service'])
     else:
         _file_line_replace('/etc/sysconfig/network', '^HOSTNAME=localhost.localdomain$', 'HOSTNAME=%s' % hostname)
         with open('/etc/hosts', 'a') as f:


### PR DESCRIPTION
### What is this PR for?

- nameserver resolver 이슈로 프로비저닝이 실패하는 이슈 해결
- 참조) http://www.linux-databook.info/?page_id=5951

### How should this be tested?

- 프로비저닝 정상 수행 확인: `vagrant up`
