### PR TITLE
DEV-14684 Gendo : AWS EB Volum 30GB -> 40GB로 증설

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -363,6 +363,12 @@ def run_create_eb_windows(name, settings, options):
     option_settings.append(oo)
 
     oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:launchconfiguration'
+    oo['OptionName'] = 'RootVolumeSize'
+    oo['Value'] = '40'
+    option_settings.append(oo)
+
+    oo = dict()
     oo['Namespace'] = 'aws:ec2:vpc'
     oo['OptionName'] = 'AssociatePublicIpAddress'
     oo['Value'] = 'false'


### PR DESCRIPTION
### What is this PR for?
- https://hbsmith.atlassian.net/browse/DEV-14678 [운영팀]storage 셋팅 메뉴발생 /  "Low disk space" 팝업 노출 테스트 실패 현상 후속 이슈
- row disk space 팝업이 뜨는 부분을 해소 하기 위함.

### How should this be tested?
- master branch johanna를 띄워주세요.
- ssh johhanna에 접속 후 /opt/johanna으로 이동해주세요.
- ./run.py create_vpc
- ./run_create_eb.py  gendo를 실행해주세요.
- AWS console에 들어가 gendo가 정상적으로 생성되었는지 확인해주세요.
- EC2 서비스 탭에 들어가 Gendo에 연결된 볼륨 스팩을 봐주세요.
- 용량이 40GB 여야 합니다.


### Screenshots (if appropriate)
**EB**
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/42234701/164137232-ae4e4b4c-c4c1-43c8-b3d5-759eb7853262.png">


**EC2** 
<img width="1428" alt="image" src="https://user-images.githubusercontent.com/42234701/164136316-b2ec2c10-b404-4f11-80e6-4e2d88e0989f.png">

**gendo Volume**
<img width="1443" alt="image" src="https://user-images.githubusercontent.com/42234701/164136928-6c3e4ae6-7a2f-4a61-a3ce-4d1e7298cd47.png">

