### PR TITLE
DEV-15241 billing 계정 IAM KEY 사용하는 자원 role 베이스로 전환

### DIFF
--- a/run_create_codebuild_common.py
+++ b/run_create_codebuild_common.py
@@ -171,6 +171,48 @@ def create_base_iam_policy(aws_cli, name, settings, role_name):
             }
             dd['Statement'].append(pp)
 
+        if 'S3_OP_BACKUP_BUCKET' in settings:
+            pp = {
+                'Effect': 'Allow',
+                'Action': [
+                    "s3:ListBucket",
+                    "s3:GetObject",
+                    "s3:GetObjectVersion",
+                    "s3:GetObjectTagging"
+                ],
+                'Resource': [
+                    f"arn:aws:s3:::{settings['S3_OP_BACKUP_BUCKET']}",
+                    f"arn:aws:s3:::{settings['S3_OP_BACKUP_BUCKET']}/*"
+                ]
+            }
+            dd['Statement'].append(pp)
+
+            pp = {
+                'Effect': 'Allow',
+                'Action': [
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:PutObjectAcl",
+                    "s3:PutObjectTagging"
+                ],
+                'Resource': [
+                    f"arn:aws:s3:::hbsmith-backup/{settings['S3_OP_BACKUP_BUCKET']}/*"
+                ],
+            }
+            dd['Statement'].append(pp)
+
+            pp = {
+                'Effect': 'Allow',
+                'Action': [
+                    "s3:ListBucket"
+                ],
+                'Resource': [
+                    f"arn:aws:s3:::hbsmith-backup"
+                ]
+            }
+            dd['Statement'].append(pp)
+
+
         if 'ARTIFACTS' in settings and settings['ARTIFACTS']['type'] == 'S3':
             pp = {
                 'Effect': 'Allow',

--- a/run_create_codebuild_common.py
+++ b/run_create_codebuild_common.py
@@ -207,11 +207,10 @@ def create_base_iam_policy(aws_cli, name, settings, role_name):
                     "s3:ListBucket"
                 ],
                 'Resource': [
-                    f"arn:aws:s3:::hbsmith-backup"
+                    "arn:aws:s3:::hbsmith-backup"
                 ]
             }
             dd['Statement'].append(pp)
-
 
         if 'ARTIFACTS' in settings and settings['ARTIFACTS']['type'] == 'S3':
             pp = {


### PR DESCRIPTION
### What is this PR for?
- codebuild project 내에서 Parameter Store 에 박혀있는 AccessKey/SecretKey 사용 -> codebuild project에 Role기반으로 대체

해당 PR은 Code build `billing_backup_op_hbsmith_script_new` 의 정책을 반영하기 위해 스크립트를 수정하였습니다.

**참고 PR**
https://github.com/HardBoiledSmith/magi/pull/894


### How should this be tested?
- 해당 브랜치의 johanna를 띄워주세요.
- 해당 브랜치의 magi/daily_cd 경로에 zip 파일을 압축 해제 해주세요.
- billing-config.json 값에 아래 스크린린샷 값을 복사하여 johanna 개인 dv config 파일에 codebuild 부분에 추가해주세요.
![image](https://user-images.githubusercontent.com/42234701/172605259-2b0ea708-adb6-4c4d-b777-383b3bfdaac3.png)
- 값의 경우 op는 master로 변경해주세요. (혹시 모를 부분을 위한 방지)
- johanna  run_create_codebuild_cron.py 파일에 아래 스크린샷을 주석처리해주세요. (일반 개인 계정에는 chatbot설정이 없어 exception이 남)
![image](https://user-images.githubusercontent.com/42234701/172605903-8bcdf945-6cbc-4835-b4c8-252c24211037.png)
- ssh로 johanna vagrant 접속 후  opt/johanna로 이동 해주세요.
- ./run_create_codebuild.py -b DEV-15241 billing_backup_op_hbsmith_script_new 를 실행해주세요.
- 정상적으로 codebuild가 생성되어야 합니다.

op를 기준으로 작성 된 값이기 때문에 build는 실패 나는게 정상입니다.
통과를 시키려면 각 개발자의 환경에 맞게 magi에 billing_backup_op_hbsmith_script_new.yml 파일을 본인의 계정에 맞게 수정해야 합니다.

### Screenshots (if appropriate)
생성된 Code Build
![image](https://user-images.githubusercontent.com/42234701/172606210-ca5d70d8-bb97-4998-81bb-16d5f2db19c4.png)

Code build에 연결된 정책
![image](https://user-images.githubusercontent.com/42234701/172606387-825fe800-af66-485a-aa0e-1239a232fd85.png)


