### PR TITLE
DEV-15320 [OP패치 지원] billing 계정 IAM KEY 사용하는 자원 role 베이스로 전환 권한 적용

### DIFF
--- a/run_create_codebuild_common.py
+++ b/run_create_codebuild_common.py
@@ -227,6 +227,22 @@ def create_base_iam_policy(aws_cli, name, settings, role_name):
             }
             dd['Statement'].append(pp)
 
+        if 'ASSUME_ROLE_ARN' in settings:
+            if 'arn:aws:iam' not in settings['ASSUME_ROLE_ARN']:
+                print('ERROR! Invalid ARN data')
+                raise Exception()
+
+            pp = {
+                'Effect': 'Allow',
+                'Action': [
+                    'sts:AssumeRole'
+                ],
+                'Resource': [
+                    f"{settings['ASSUME_ROLE_ARN']}",
+                ]
+            }
+            dd['Statement'].append(pp)
+
         cmd = ['iam', 'create-policy']
         cmd += ['--policy-name', policy_name]
         cmd += ['--path', '/service-role/']


### PR DESCRIPTION
### What is this PR for?
- codebuild를 만들 때 생성되는 권한에 STS를 써야하는 경우가 존재함. ( 타 계정에 대해선 STS를 통해 가져와야 함 )
- AWS CLI에서 STS를 사용 할 수 있도록 내용 추가.

**연관PR**
https://github.com/HardBoiledSmith/magi/pull/897