### PR TITLE
DEV-15515 imagebuilder 생성 시 Error 발생 후 Fail 나도록 변경

### DIFF
--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -84,8 +84,10 @@ def run_create_image_builder(options):
     except Exception as ee:
         if latest_eb_platform_ami.strip() != target_eb_platform_version.strip():
             print_session('Pleas Check Your eb platfrom version. \n'
+                          '----------------------------------------------------\n'
                           f'latest eb platform ami : {latest_eb_platform_ami}\n'
-                          f'eb platform ami : {target_eb_platform_version}\n '
+                          f'target eb platform ami : {target_eb_platform_version}\n '
+                          '----------------------------------------------------\n'
                           'Reference : https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/'
                           'platforms-supported.html#platforms-supported.net')
         raise ee

--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -88,7 +88,6 @@ def run_create_image_builder(options):
                           f'eb platform ami {target_eb_platform_version}\n '
                           'Reference : https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/'
                           'platforms-supported.html#platforms-supported.net')
-            return
         raise ee
 
     eb_platform_ami = ''

--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -85,7 +85,7 @@ def run_create_image_builder(options):
         if latest_eb_platform_ami.strip() != target_eb_platform_version.strip():
             print_session('Pleas Check Your eb platfrom version. \n'
                           f'latest eb platform ami : {latest_eb_platform_ami}\n'
-                          f'eb platform ami {target_eb_platform_version}\n '
+                          f'eb platform ami : {target_eb_platform_version}\n '
                           'Reference : https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/'
                           'platforms-supported.html#platforms-supported.net')
         raise ee


### PR DESCRIPTION
### What is this PR for?
- 그대로 return을 하여 codebuild가 성공으로 나옴. Fail이 되도록 return 되는 코드를 제거.
<img width="1708" alt="image" src="https://user-images.githubusercontent.com/42234701/179957833-03ac3113-2479-4170-bedd-f5f2601e05bc.png">

### How should this be tested?
- run_create_imagebuilder_gendo가 정상적으로 수행 되어야 합니다.
- 최신 버전이 아닐 경우 raise가 되어 Codebuild에서 Fail이 나야 합니다.