### PR TITLE
DEV-17298 [gendo][hoftix] 비용절감을 위한 gendo 스케일링 정책 조정

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -37,6 +37,8 @@ def run_create_eb_windows(name, settings, options):
     service_name = env['common'].get('SERVICE_NAME', '')
     name_prefix = f'{service_name}_' if service_name else ''
     url = settings['ARTIFACT_URL']
+    time_base_scale_in_desired_capacity = settings['TIME_BASE_SCALE_IN_DESIRED_CAPACITY']
+    time_base_scale_out_desired_capacity = settings['TIME_BASE_SCALE_OUT_DESIRED_CAPACITY']
     cidr_subnet = aws_cli.cidr_subnet
 
     str_timestamp = str(int(time.time()))
@@ -366,6 +368,76 @@ def run_create_eb_windows(name, settings, options):
     oo['Namespace'] = 'aws:autoscaling:launchconfiguration'
     oo['OptionName'] = 'RootVolumeSize'
     oo['Value'] = '40'
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime'
+    oo['OptionName'] = 'MinSize'
+    oo['Value'] = aws_asg_min_value
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime'
+    oo['OptionName'] = 'MaxSize'
+    oo['Value'] = aws_asg_max_value
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime'
+    oo['OptionName'] = 'DesiredCapacity'
+    oo['Value'] = time_base_scale_in_desired_capacity
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime'
+    oo['OptionName'] = 'StartTime'
+    oo['Value'] = '2023-01-01T07:00:00Z'
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime'
+    oo['OptionName'] = 'Recurrence'
+    oo['Value'] = "0 13 * * *"
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleUpSpecificTime'
+    oo['OptionName'] = 'MinSize'
+    oo['Value'] = aws_asg_min_value
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleUpSpecificTime'
+    oo['OptionName'] = 'MaxSize'
+    oo['Value'] = aws_asg_max_value
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleUpSpecificTime'
+    oo['OptionName'] = 'DesiredCapacity'
+    oo['Value'] = time_base_scale_out_desired_capacity
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleUpSpecificTime'
+    oo['OptionName'] = 'StartTime'
+    oo['Value'] = '2023-01-01T07:00:00Z'
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleUpSpecificTime'
+    oo['OptionName'] = 'Recurrence'
+    oo['Value'] = "0 22 * * *"
     option_settings.append(oo)
 
     oo = dict()


### PR DESCRIPTION
### What is this PR for?
- [gendo][hoftix] 비용절감을 위한 gendo 스케일링 정책 조정
    - 2023.1.4 스크럼 회의에서 논의한 방향대로 진행했습니다.
        - 오전 7시에 인스턴스 생성
        - 오후 10시 인스턴스 축소
    - 개발환경에 따라 분기를 타도록 해야하나 고민했으나, OP환경과 값은 다를 수 있어도 환경은 동일하게 구성해야 테스트가 될 수 있기에 환경에따른 분리를 하지 않았습니다.

**관련 PR**
https://github.com/HardBoiledSmith/magi/pull/1002


### How should this be tested?
- 논의한 방향

### Screenshots (if appropriate)

<img width="1396" alt="image" src="https://user-images.githubusercontent.com/42234701/210499182-dd665da9-8467-4339-9459-3acf17294254.png">
오전 7시에 늘리기 작업
오후 10시에 줄이기 작업

- 최소 최대 조절량을 1로 설정해도 잘 생성되는 부분 확인했습니다 ( 개발환경의 경우 세팅을 1로 할 예정)
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/42234701/210499054-98fc94b7-5520-44f3-b06d-2243bba77b89.png">
