### PR TITLE
DEV-17638 [gendo] HotFix: 스케일링 정책 수정

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -512,7 +512,7 @@ class AWSCli:
             elapsed_time += 5
 
     def get_eb_gendo_windows_platform(self, target_service):
-        in_use_eb_windows_version = '2.10.7'
+        in_use_eb_windows_version = '2.11.0'
 
         if target_service == 'elastic_beanstalk':
             return f'64bit Windows Server 2016 v{in_use_eb_windows_version} running IIS 10.0'

--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -39,6 +39,7 @@ def run_create_eb_windows(name, settings, options):
     url = settings['ARTIFACT_URL']
     time_base_scale_in_desired_capacity = settings['TIME_BASE_SCALE_IN_DESIRED_CAPACITY']
     time_base_scale_out_desired_capacity = settings['TIME_BASE_SCALE_OUT_DESIRED_CAPACITY']
+    time_base_scale_in_sub_desired_capacity = settings['TIME_BASE_SCALE_IN_SUB_DESIRED_CAPACITY']
     cidr_subnet = aws_cli.cidr_subnet
 
     str_timestamp = str(int(time.time()))
@@ -403,6 +404,41 @@ def run_create_eb_windows(name, settings, options):
     oo['ResourceName'] = 'ScheduledScaleDownSpecificTime'
     oo['OptionName'] = 'Recurrence'
     oo['Value'] = "0 13 * * *"
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime2'
+    oo['OptionName'] = 'MinSize'
+    oo['Value'] = aws_asg_min_value
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime2'
+    oo['OptionName'] = 'MaxSize'
+    oo['Value'] = aws_asg_max_value
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime2'
+    oo['OptionName'] = 'DesiredCapacity'
+    oo['Value'] = time_base_scale_in_sub_desired_capacity
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime2'
+    oo['OptionName'] = 'StartTime'
+    oo['Value'] = '2023-01-01T07:00:00Z'
+    option_settings.append(oo)
+
+    oo = dict()
+    oo['Namespace'] = 'aws:autoscaling:scheduledaction'
+    oo['ResourceName'] = 'ScheduledScaleDownSpecificTime2'
+    oo['OptionName'] = 'Recurrence'
+    oo['Value'] = "0 15 * * *"
     option_settings.append(oo)
 
     oo = dict()


### PR DESCRIPTION
### What is this PR for?
- DEV-17638 [gendo] HotFix: 스케일링 정책 수정
    - scale out 조건 5 → 60으로 변경
    - Time Base 스케줄 조정 조건 한 개 추가 

**연관PR**
https://github.com/HardBoiledSmith/magi/pull/1018

### How should this be tested?

- 해당브랜치의 johanna, magi 파일 압축해제.
- ./run_create_vpc.py , ./run_create_eb.py gendo 실행 시 이상이 없어야 하고 아래 스크린샷 처럼 반영이 되었는지 확인.

### Screenshots (if appropriate)

Time Base 스케줄 조정 한 개 추가 ( 자정 15대 )
<img width="1379" alt="image" src="https://user-images.githubusercontent.com/42234701/215670249-f1936832-87d0-4526-a85d-48ffacf1403f.png">

5 -> 60으로 변경
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/42234701/215670401-0f49e4f7-035b-431a-8f93-f821986695d2.png">

