### PR TITLE
DEV-18501 EB window platform version update 2.11.3 -> 2.11.4

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -512,7 +512,7 @@ class AWSCli:
             elapsed_time += 5
 
     def get_eb_gendo_windows_platform(self, target_service):
-        in_use_eb_windows_version = '2.11.3'
+        in_use_eb_windows_version = '2.11.4'
 
         if target_service == 'elastic_beanstalk':
             return f'64bit Windows Server 2016 v{in_use_eb_windows_version} running IIS 10.0'


### PR DESCRIPTION
### What is this PR for?
- EB window platform version update 2.11.3 -> 2.11.4
<img width="999" alt="image" src="https://github.com/HardBoiledSmith/johanna/assets/42234701/d6ad2e60-9e15-4430-a56f-8b52e2792b12">
출처 : https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.python


- EB python은 업데이트 된 버전이 없어 반영하지 않았습니다.

### How should this be tested?
- imagebuilder 서비스 Gendo 이미지 생성 성공