### PR TITLE
DEV-18625 [라미엘] 응답없는 맥미니 cloudwatch - pagerduty 알람 모니터링 추가

### DIFF
--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -39,7 +39,7 @@ def _create_route53_health_check_and_alarm(domain, settings, unique_domain=None)
     timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M')
     caller_reference = f'{name}-{timestamp}' if not unique_domain else f'{name}-{domain}-{port}-{timestamp}'
     cmd += ['--caller-reference', caller_reference]
-    cmd += ['--health-check-config', json.dumps(data)]
+    cmd += ['--health-check-config', json.dumps(dd)]
     rr = aws_cli.run(cmd)
 
     healthcheck_id = rr['HealthCheck']['Id']

--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -53,7 +53,7 @@ def _create_route53_health_check_and_alarm(domain, settings, unique_domain=None)
     aws_cli = AWSCli(healthcheck_region)
 
     alarm_name = f'{name}-{healthcheck_region}-{settings["METRIC_NAME"]}' if not unique_domain \
-        else f'{name}-{healthcheck_region}-{unique_domain}-{settings["METRIC_NAME"]}'
+        else f'{name}-{healthcheck_region}-{domain}-{port}-{settings["METRIC_NAME"]}'
     print_message('create or update cloudwatch alarm: %s' % alarm_name)
 
     time.sleep(5)

--- a/run_terminate_route53_health_check.py
+++ b/run_terminate_route53_health_check.py
@@ -1,29 +1,52 @@
 #!/usr/bin/env python3
 
+import re
+
 from env import env
-from run_common import AWSCli
+from run_common import AWSCli, print_message
 from run_common import parse_args
 
 
-def delete_route53_health_check(settings):
+def _delete_route53_health_check_and_alarm(domain, settings, unique_domain=None):
     aws_cli = AWSCli()
     name = settings['NAME']
 
     cmd = ['route53', 'list-health-checks']
     rr = aws_cli.run(cmd)
 
-    for r in rr['HealthChecks']:
-        if r['CallerReference'].startswith(name):
-            cmd = ['route53', 'delete-health-check']
-            cmd += ['--health-check-id', r['Id']]
-            aws_cli.run(cmd)
+    match = re.search(r'(.*):(\d+)$', domain)
+    port = 443
+    if match:
+        domain = match.group(1)
+        port = int(match.group(2))
 
-            healthcheck_region = 'us-east-1'
-            aws_cli = AWSCli(healthcheck_region)
-            alarm_name = f'{name}-{healthcheck_region}-{settings["METRIC_NAME"]}'
-            cmd = ['cloudwatch', 'delete-alarms']
-            cmd += ['--alarm-names', alarm_name]
-            aws_cli.run(cmd)
+    for r in rr['HealthChecks']:
+        if not r['CallerReference'].startswith(name):
+            continue
+
+        cmd = ['route53', 'delete-health-check']
+        cmd += ['--health-check-id', r['Id']]
+        aws_cli.run(cmd)
+
+        healthcheck_region = 'us-east-1'
+        aws_cli = AWSCli(healthcheck_region)
+        alarm_name = f'{name}-{healthcheck_region}-{settings["METRIC_NAME"]}' if not unique_domain \
+            else f'{name}-{healthcheck_region}-{domain}-{port}-{settings["METRIC_NAME"]}'
+        cmd = ['cloudwatch', 'delete-alarms']
+        cmd += ['--alarm-names', alarm_name]
+        aws_cli.run(cmd)
+
+
+def delete_route53_health_check(settings):
+    if settings.get('TARGETDOMAINNAME'):
+        domain = settings['TARGETDOMAINNAME']
+        _delete_route53_health_check_and_alarm(domain, settings)
+    elif settings.get('TARGETDOMAINNAME_LIST'):
+        ll = settings['TARGETDOMAINNAME_LIST'].split(',')
+        for domain in ll:
+            _delete_route53_health_check_and_alarm(domain, settings, True)
+    else:
+        print_message(f"[SKIPPED] {settings['NAME']}: TARGETDOMAINNAME or TARGETDOMAINNAME_LIST is not set")
 
 
 ################################################################################


### PR DESCRIPTION
### What is this PR for?

- 이 PR이 해결하고자 하는 이슈(JIRA Issue) 및 작업 내용에 대해 설명해 주세요
- 참조
    - [johanna](https://github.com/HardBoiledSmith/johanna/pull/721)
    - [magi](https://github.com/HardBoiledSmith/magi/pull/1092)
    - [ws-scrcpy](https://github.com/HardBoiledSmith/ws-scrcpy/pull/159)

### How should this be tested?

- magi 설정 생성 및 johanna에 설정 복사
    - sns --> ramiel --> `"NAME": "ramiel-status-notification",` 를 포함한 dict 있는지 확인
    - route53 --> ramiel --> `"NAME": "ramiel",` 항목 확인 --> 해당 항목에 `"TARGETDOMAINNAME_LIST": "idc-yatab-1.hbsmith.io:28500,idc-yatab-2.hbsmith.io:28501",` 설정
- johanna 배포: `BRANCH=DEV-18626 vagrant up`
- aws 자산 배포
    - sns: `./run_create_sns.py -f ramiel-status-notification`
    - cloudwatch alarm, route53 상태 점검: `./run_create_route53_health_check.py -f`
- 생성 자원 확인
    - aws --> sns --> 
    - aws --> route53 --> 상태 점검
    - aws --> cloudwatch --> 알람
- 확인 끝났으면 aws 자산 모두 석제
    - sns: `./run_terminate_sns -f`
    - route53 health check: `./run_terminate_route53_health_check.py -f`

### Screenshots (if appropriate)

<img width="527" alt="image" src="https://github.com/HardBoiledSmith/johanna/assets/12525941/5093b88f-8306-44b5-8ff9-e61663e7c354">

<img width="1361" alt="image" src="https://github.com/HardBoiledSmith/johanna/assets/12525941/99c8621d-850c-4f80-9a05-57ee8f3aaddd">

개발팀 라미엘에 echo 활성화 후 상태 검사기가 정상 작동한 사례
<img width="1377" alt="image" src="https://github.com/HardBoiledSmith/johanna/assets/12525941/059db2c6-bc6d-443c-bd8a-4c494d32166c">

알람이 발생한 사례 (개발팀 라미엘 배포 이슈로 발생)

