### PR TITLE
DEV-19042 [라미엘] Route53 health checker 민감도 조정

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ You can use this on web GUI
 ./run_create_route53.py -ah Z2FDTNDATAQYW2 -at cloudfront -d <cloudfront domain name> -hn hbsmith.io -n <domain> -r A -f
 ```
 
+# Script to create route 53 health check
+
+- Full deployment: `./run_create_route53_health_check.py`
+- Partial deployment: `./run_create_route53_health_check.py <name>`
+  - ex) `./run_create_route53_health_check.py ramiel`
+- Partial termination: `./run_terminate_route53_health_check.py <name>`
+  - ex) `./run_terminate_route53_health_check.py ramiel`
+
 # Notes
 
 * If you use AWS IAM user credential instead of master account, it must have IAMFullAccess,

--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -11,11 +11,9 @@ from env import env
 from run_common import print_message
 
 
-def _create_route53_health_check_and_alarm(domain, settings, unique_domain=None, target_name=None):
+def _create_route53_health_check_and_alarm(domain, settings, unique_domain=None):
     aws_cli = AWSCli()
     name = settings['NAME']
-    if target_name and name != target_name:
-        return
 
     print_message('create Route53 health check: %s' % name)
 
@@ -91,7 +89,7 @@ def create_route53_health_check(settings, target_name):
     elif settings.get('TARGETDOMAINNAME_LIST'):
         ll = settings['TARGETDOMAINNAME_LIST'].split(',')
         for domain in ll:
-            _create_route53_health_check_and_alarm(domain, settings, True, target_name)
+            _create_route53_health_check_and_alarm(domain, settings, True)
     else:
         print_message(f"[SKIPPED] {settings['NAME']}: TARGETDOMAINNAME or TARGETDOMAINNAME_LIST is not set")
 
@@ -104,9 +102,17 @@ def create_route53_health_check(settings, target_name):
 if __name__ == '__main__':
     _, args = parse_args()
 
+    target_found = False
     target_name = None
     if len(args) > 1:
         target_name = args[1]
 
     for settings in env.get('route53', list()):
+        if target_name and settings['NAME'] != target_name:
+            continue
+
+        target_found = True
         create_route53_health_check(settings, target_name)
+
+    if not target_found:
+        print_message('target not found')

--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -14,8 +14,7 @@ from run_common import print_message
 def _create_route53_health_check_and_alarm(domain, settings, unique_domain=None, target_name=None):
     aws_cli = AWSCli()
     name = settings['NAME']
-
-    if name != target_name:
+    if target_name and name != target_name:
         return
 
     print_message('create Route53 health check: %s' % name)


### PR DESCRIPTION
### What is this PR for?

- route53 health check 부분 배포/정리 기능 추가
- 참조
    - https://github.com/HardBoiledSmith/magi/pull/1105
    - https://github.com/HardBoiledSmith/johanna/pull/728

### How should this be tested?

- 배포
    - magi에서 DEV-19042 체크아웃 --> 개인 seele 압축 해제 --> route53 --> ramiel에 내용 변경:`"TARGETDOMAINNAME_LIST": "idc-yatab-1.hbsmith.io:28500,idc-yatab-2.hbsmith.io:28501,idc-yatab-2.hbsmith.io:28502,idc-yatab-2.hbsmith.io:28503",` --> johanna에 config.json 복사
    - johanna를 DEV-19042로 배포
 - johanna에 ssh 접속
 - route53 health check 부분 배포: ./run_create_route53_health_check.py ramiel -f
 - AWS 콘솔 확인
 - route53 health check 부분 삭제: ./run_terminate_route53_health_check.py ramiel -f

### Screenshots (if appropriate)

30 x 10 으로 민감도 연장 확인
![image](https://github.com/HardBoiledSmith/johanna/assets/12525941/822e2633-212f-4f69-b4fe-16c678f481b4)
