### PR TITLE
DEV-19640 eb gendo platform version update 2.11.8 -> 2.12.0

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -512,7 +512,7 @@ class AWSCli:
             elapsed_time += 5
 
     def get_eb_gendo_windows_platform(self, target_service):
-        in_use_eb_windows_version = '2.11.8'
+        in_use_eb_windows_version = '2.12.0'
 
         if target_service == 'elastic_beanstalk':
             return f'64bit Windows Server 2016 v{in_use_eb_windows_version} running IIS 10.0'

--- a/run_create_eb_django.py
+++ b/run_create_eb_django.py
@@ -453,7 +453,7 @@ def run_create_eb_django(name, settings, options):
     cmd += ['--cname-prefix', cname]
     cmd += ['--environment-name', eb_environment_name]
     cmd += ['--option-settings', option_settings]
-    cmd += ['--solution-stack-name', '64bit Amazon Linux 2 v3.5.7 running Python 3.8']
+    cmd += ['--solution-stack-name', '64bit Amazon Linux 2 v3.5.8 running Python 3.8']
     cmd += ['--tags', tag0, tag1]
     cmd += ['--version-label', eb_environment_name]
     aws_cli.run(cmd, cwd=template_path)


### PR DESCRIPTION
### What is this PR for?
- DEV-19640 eb gendo platform version update 2.11.8 -> 2.12.0
- 참고 : https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-supported.html#platforms-supported.net
### Test
- code build ( billing_create_gendo_image )가 성공 해야 합니다.