### PR TITLE
DEV-21827 [gendo] You must specify a region. You can also configure your region by running "aws configure".

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -718,6 +718,16 @@ def run_create_eb_windows(name, settings, options):
     oo['Value'] = eb_environment_name
     option_settings.append(oo)
 
+    oo['Namespace'] = 'aws:elasticbeanstalk:application:environment'
+    oo['OptionName'] = 'AWS_REGION'
+    oo['Value'] = aws_region
+    option_settings.append(oo)
+
+    oo['Namespace'] = 'aws:elasticbeanstalk:application:environment'
+    oo['OptionName'] = 'AWS_DEFAULT_REGION'
+    oo['Value'] = aws_region
+    option_settings.append(oo)
+
     option_settings = json.dumps(option_settings)
 
     tag0 = f"Key=git_hash_johanna,Value={git_hash_johanna.decode('utf-8').strip()}"


### PR DESCRIPTION
### What is this PR for?

- 간헐적으로 발생하는 `You must specify a region. You can also configure your region by running "aws configure".` 에러를 해결시도.
- 강제로 AWS_DEFAULT_REGION, AWS_REGION을 환경변수로 설정. boto3나 aws cli가 이를 이용하도록 함
- 연관 PR: https://github.com/HardBoiledSmith/gendo/pull/1814

### How should this be tested?

- 정상적으로 프로비저닝 되어야 함
- 정상적으로 스크립트 다운로드, 테스트 수행, 결과 업로드 되어야 함 
