### PR TITLE
DEV-21876 [Gendo] 구버전 Gendo에서 테스트가 돌아가는 현상 조사

### DIFF
--- a/run_create_eb_windows.py
+++ b/run_create_eb_windows.py
@@ -835,7 +835,7 @@ def run_create_eb_windows(name, settings, options):
         else:
             print("No CloudWatch Alarms found.")
 
-        print(f"Describe eb old autoscaling group sscheduled actions")
+        print("Describe eb old autoscaling group scheduled actions")
         cmd = ['autoscaling', 'describe-scheduled-actions']
         cmd += ['--auto-scaling-group-name', eb_old_autoscaling_group_name]
         cmd += ['--query', "ScheduledUpdateGroupActions[*].ScheduledActionName"]


### PR DESCRIPTION
### What is this PR for?
- 구버전 Gendo가 종료되지 않고 스크립트들이 실행되고 있는 현상 발견.
- Gendo 환경 교체 되면서 구 버전은 0대로 만들어졌으나, 구 버전 환경 정리 코드가 실행 되기 전 인스턴스 갯수 스케줄링으로 인해 갯수가 늘어나 구버전이 정리되지 않음.
- 환경 교체 후 0대로 줄이기 전 구버전 Gendo에 대한 instance 조정 trigger 이벤트들을 삭제 하도록 함.
- Gendo 인스턴스 수 조절 관여하는 서비스는 (Cloudwatch, Auto Scaling Group) 에 있습니다.


### How should this be tested?
- aws 환경 구성해주세요.
- run_create_vpc.py
- run_create_eb.py gendo
- 생성 완료 후 cloudwatch, autoscaling group에 걸려있는 스케줄 베이스 조정 정책이 있는지 확인합니다.
- run_create_eb.py gendo
- 실행하여 교체 후 구버전 Gendo에 대한 instance 관련 작업이 모두 삭제 되어 있는지 확인해주세요.

### Screenshots (if appropriate)
<img width="538" alt="image" src="https://github.com/user-attachments/assets/d4aee522-99f8-4731-8736-2100c628dcd7">

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/225d8603-67b5-47f8-bcdc-4a864a100846">
