### PR TITLE
DEV-22291 datetime 관련 deprecated 해결

### DIFF
--- a/run_create_route53_health_check.py
+++ b/run_create_route53_health_check.py
@@ -4,6 +4,7 @@ import json
 import re
 import time
 from datetime import datetime
+from datetime import timezone
 
 from env import env
 from run_common import AWSCli
@@ -40,7 +41,7 @@ def _create_route53_health_check_and_alarm(domain, settings, unique_domain=None)
         dd['EnableSNI'] = False
 
     cmd = ['route53', 'create-health-check']
-    timestamp = datetime.utcnow().strftime('%Y-%m-%dT%H:%M')
+    timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M')
     caller_reference = f'{name}-{timestamp}' if not unique_domain else f'{name}-{domain}-{port}-{timestamp}'
     cmd += ['--caller-reference', caller_reference]
     cmd += ['--health-check-config', json.dumps(dd)]


### PR DESCRIPTION
### What is this PR for?
- DEV-22291 datetime 관련 deprecated 해결

**케이스 1**
datetime.utcnow() → datetime.now(timezone.utc) 으로 변경

**케이스 2**
a = datetime.now(timezone.utc)
b = datetime.strftime("") (timezone 없음)

### How should this be tested?
- 기존 기능들에서 에러없이 동작 해야 합니다