### PR TITLE
DEV-23220 imagebulider requirements.txt 패키지 설치 실패 시 이미지 생성 실패되도록 코드 수정 필요

### DIFF
--- a/run_common.py
+++ b/run_common.py
@@ -512,7 +512,7 @@ class AWSCli:
             elapsed_time += 5
 
     def get_eb_gendo_windows_platform(self, target_service):
-        in_use_eb_windows_version = '2.19.1'
+        in_use_eb_windows_version = '2.19.2'
 
         if target_service == 'elastic_beanstalk':
             return f'64bit Windows Server 2016 v{in_use_eb_windows_version} running IIS 10.0'

--- a/run_create_imagebuilder_gendo.py
+++ b/run_create_imagebuilder_gendo.py
@@ -108,6 +108,7 @@ def run_create_image_builder(options):
     for ll in tmp_lines:
         ll = ll.replace('\n', '')
         tt = f'{" " * 14}python -m pip install {ll}\n'
+        tt += f'{" " * 14}if ($LASTEXITCODE -ne 0) {{ throw "Failed to install package: {ll}" }}\n'
         lines.append(tt)
     pp = ''.join(lines)
 
@@ -193,9 +194,6 @@ def run_create_image_builder(options):
     cmd += ['--instance-profile-name', instance_profile_name]
     cmd += ['--instance-types', 'r7i.large']
     cmd += ['--terminate-instance-on-failure']
-    # TODO: For debugging failed build, uncomment the following line
-    # cmd += ['--no-terminate-instance-on-failure']
-    # cmd += ['--key-pair', 'gendo-key-pair']
     cmd += ['--description', f'생성일자 : {kst_date_time_now}']
     cmd += ['--tags', f'{git_hash_johanna_tag},{git_hash_gendo_tag},{target_eb_platform_version_tag}, {base_ami_tag}']
     rr = aws_cli.run(cmd)


### PR DESCRIPTION
### What is this PR for?
-  imagebulider requirements.txt 패키지 설치 실패 시 이미지 생성 실패되도록 코드 수정 필요
- 패키지 정상 설치가 되지 않았음에도 이미지가 생성되어 서버 생성전까지 인지를 하지 못햇음.
- 이에따라, 패키지 버전 설치 시 에러발생한 경우 이미지 빌드 실패되도록 코드 변경함.

https://github.com/HardBoiledSmith/gendo/pull/1985

### How should this be tested?
- ./run_create_imagebuilder_gendo.py -b DEV-23220을 실행해주세요.
- 테스트 실패를 확인하기 위해선 requirement.txt에 설치가 실패하는 버전으로 수정해야합니다.

### Screenshots (if appropriate)
<img width="1741" alt="image" src="https://github.com/user-attachments/assets/794ca753-741b-44d4-8ae4-38c8c76d92f0" />
<img width="1570" alt="image" src="https://github.com/user-attachments/assets/fffa1cac-f169-44ad-80a3-7c00d6fac1fe" />

<img width="1720" alt="image" src="https://github.com/user-attachments/assets/02649b97-d19a-4ee9-a050-6b8296f2c7a7" />

